### PR TITLE
add a CONTRIBUTORS.yaml file for fancy hover

### DIFF
--- a/_data/CONTRIBUTORS.yaml
+++ b/_data/CONTRIBUTORS.yaml
@@ -1,0 +1,36 @@
+# List of contributors
+#
+# reference maintainers/contributors by their name used in contributors metadata section on the pages.
+# Extra metadata that is possible to add:
+# Full Name:
+#    git: github id
+#    email: email adress
+#    orcid: ocrid id
+#    role: the role of the contributor
+#    affiliation: affiliation
+#    image_url: absolute path to image (default image from github)
+
+Laura Portell Silva:
+    git: lauportell
+    email: laura.portell@bsc.es
+    orcid: 0000-0003-0390-3208
+    role: editor
+    affiliation: Barcelona Supercomputing Center / ELIXIR-ES
+Carole Goble:
+    git: CaroleGoble
+    orcid: 0000-0003-1219-2137
+    affiliation: The University of Manchester / ELIXIR-UK
+Fotis Psomopoulos:
+    git: fpsom
+    orcid: 0000-0002-0222-4273
+    email: fpsom@certh.gr
+    affiliation: Institute of Applied Biosciences(INAB|CERTH) / ELIXIR-GR 
+Salvador Capella-Gutierrez:
+    email: salvador.capella@bsc.es 
+    affiliation: Barcelona Supercomputing Centre (BSC) 
+Patrick Bos:
+    git: egpbos
+    email: p.bos@esciencecenter.nl
+    orcid: 0000-0002-6033-960X
+    role: editor
+    affiliation: Netherlands eScience Center


### PR DESCRIPTION
Copied from the RDMkit, including some names we recognize from their list (@fpsom @lauportell and Carole and Salva whose GitHub handles don't autocomplete for me 😄). I don't see any configuration files at the RDMkit side, so I think this should work out of the box.

For more fanciness: they also have a nice [auto-generated contributors page](https://rdmkit.elixir-europe.org/contributors) that we could consider adding, for which we would need the following page: https://github.com/elixir-europe/rdmkit/blob/master/pages/about/contributors.md?plain=1

Existing contributors, feel free to add your name to the list either in this PR branch or later in a separate one @anenadic @dgarijo @shoaibsufi @gperu @KirstyPringle @kosarko @christianhueserhzdr @roiser @juckel @Anas-Elhounsri 