### PR TITLE
add Matomo analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ topnav_banner: "The current version of RSQKit is a work in progress. Any content
 description: "The Research Software Quality Kit is a resource to help researchers that code, Research Software Engineers, and anyone in between learn about and apply best practices in creating research software and code."
 # Metadata description of the website
 
-remote_theme: ELIXIR-Belgium/elixir-toolkit-theme
+remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@3.2.0
 
 
 sass:

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,10 @@ sass:
   style: compressed
   sourcemap: never
 
+matomo: https://matomo.research.software/
+# Matomo domain where Matomo is running
+matomo_id: 7
+
 exclude:
   - README.md
   - Gemfile

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -6,6 +6,22 @@ columns:
     width: 3
     src: 'assets/img/everse_logo.png'
     alt: EVERSE logo
+  - type: links
+    width: 1
+    children:
+      - url_text: Get involved
+        url: /how_to_get_involved
+      - url_text: EVERSE
+        url: https://everse.software
+  - type: links
+    width: 1
+    children:
+      - url_text: About
+        url: /about
+      - url_text: Contact
+        url: /contact
+      - url_text: Privacy
+        url: /privacy
   - type: image
     image_width: 100px
     width: 2

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,140 @@
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+    {%- capture keywords %}
+    {%- if page.related_pages %}
+    {%- for section in page.related_pages %}
+    {%- unless section[1].size == 0 %}
+    {%- for keywordstr in section[1] %}
+    {%- assign keywordpage = site.pages | where: "page_id", keywordstr | first  %}
+    {%- if allkeywords %}
+    {%- assign allkeywords = allkeywords | append: ", " | append: keywordstr | append: ", " | append: keywordpage.title %}
+    {%- else %}
+    {%- assign allkeywords = allkeywords | append: keywordstr | append: ", " | append: keywordpage.title %}
+    {%- endif %}
+    {%- endfor %}
+    {%- endunless %}
+    {%- endfor %}{{allkeywords}}
+    {%- endif %}
+    {%- endcapture %}
+    <meta name="keywords" content="{{keywords}}">
+    <meta property="og:title" content="{{ site.title }}" />
+    <meta property="og:description" content="{{ site.description }}" />
+    <meta property="og:image" content="//{{site.github.url | remove: 'https://' | remove: 'http://'}}/assets/img/apple-touch-icon.png" />
+    <meta name="apple-mobile-web-app-title" content="{{site.title}}">
+    <meta name="msapplication-TileColor" content="#{{site.theme_variables.theme_color | default: 0d6efd }}">
+    <meta name="theme-color" content="#{{site.theme_variables.theme_color | default: 0d6efd }}">
+    {%- if page.no_robots %}
+    <meta name="robots" content="noindex" />
+    {%- endif %}
+    {%- if page.type %}
+    {%- assign subtitle = page.type | replace: "_", " " | capitalize %}
+    {%- endif %}
+    <title>{% if page.title %}{% if subtitle %}{{subtitle}}: {% endif %}{{ page.title }} | {{ site.title }}{%- else %}{{ site.title }}{% endif %}</title>
+    <!-- Syntax highlighting  -->
+    <link rel="stylesheet" href="{{ 'assets/css/syntax.css' | relative_url }}">
+    <!-- Country flags  -->
+    <link rel="stylesheet" href="{{ 'assets/css/flag-icon.min.css' | relative_url }}">
+    <!-- Font Awesome -->
+    <link rel="stylesheet" type="text/css" href="{{ 'assets/css/all.min.css' | relative_url }}">
+    <!-- Main css file -->
+    <link rel="stylesheet" href="{{ 'assets/css/main.css' | relative_url }}?{{site.time | date: '%s'}}">
+    {%- if site.theme_variables.fonts.size != 0 %}
+    <!-- Main font(s) -->
+    {%- for font in site.theme_variables.fonts %}
+    <link href="{{font}}" rel="stylesheet">
+    {%- endfor %}
+    {%- endif %}
+    <!-- JavaScript  -->
+    <script src="{{ 'assets/js/jquery.min.js' | relative_url }}"></script>
+    <script src="{{ 'assets/js/lunr.min.js' | relative_url }}"></script>
+    <script src="{{ 'assets/js/bootstrap.bundle.min.js' | relative_url }}"></script>
+    <script src="{{ 'assets/js/anchor.min.js' | relative_url }}"></script>
+    {% if page.toc or page.toc == nil %}<script src="{{ 'assets/js/toc.js' | relative_url }}?{{site.time | date: '%s'}}"></script>{% endif %}
+    <script src="{{ 'assets/js/jquery.navgoco.js' | relative_url }}"></script>
+    <script src="{{ 'assets/js/main.js' | relative_url }}?{{site.time | date: '%s'}}"></script>
+    <script src="{{ 'assets/js/search.js' | relative_url }}"></script>
+    <script src="{{ 'assets/js/clipboard.min.js' | relative_url }}"></script>
+    {%- if page.datatable == true %}
+    <!-- Include the standard DataTables bits -->
+    <link rel="stylesheet" type="text/css" href="{{ 'assets/css/dataTables.bootstrap5.min.css' | relative_url }}">
+    <script type="text/javascript" charset="utf8" src="{{ 'assets/js/jquery.dataTables.min.js' | relative_url }}"></script>
+    <script type="text/javascript" charset="utf8" src="{{ 'assets/js/dataTables.bootstrap5.min.js' | relative_url }}"></script>
+    {%- if site.theme_variables.datatables.searchbuilder %}
+    <link rel="stylesheet" type="text/css" href="{{ 'assets/css/dataTables.dateTime.min.css' | relative_url }}">
+    <link rel="stylesheet" type="text/css" href="{{ 'assets/css/searchBuilder.bootstrap5.min.css' | relative_url }}">
+    <script type="text/javascript" charset="utf8" src="{{ 'assets/js/dataTables.searchBuilder.min.js' | relative_url }}"></script>
+    <script type="text/javascript" charset="utf8" src="{{ 'assets/js/dataTables.dateTime.min.js' | relative_url }}"></script>
+    <script type="text/javascript" charset="utf8" src="{{ 'assets/js/searchBuilder.bootstrap5.min.js' | relative_url }}"></script>
+    {%- endif %}
+    <script type="text/javascript">
+        $(document).ready(function () {
+            $('table.display').each(function() {
+                $(this).DataTable({
+                    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+                    stateSave: true,
+                    searching: true,
+                    {%- if site.theme_variables.datatables.searchbuilder %}
+                    layout: {
+                        top1Start: 'searchBuilder'
+                    },
+                    {%- endif %}
+                    info: true,
+                    pageLength: 10,
+                    language: {
+                        searchPlaceholder: "Type here..."
+                    },
+                    "drawCallback": function ( settings ){
+                        var tableId = settings.nTable.id;
+                        if(settings.fnRecordsTotal() < 10){     
+                            $('#'+tableId+'_wrapper .dt-length').hide();
+                            $('#'+tableId+'_wrapper .dt-paging').hide();
+                            $('#'+tableId+'_wrapper .dt-search').hide();
+                            $('#'+tableId+'_wrapper .dt-info').hide();
+                        }
+                        $('.dt-layout-table .dt-layout-full').addClass('table-responsive');
+                    }
+                });
+            })
+        });
+    </script>
+    {%- endif %}
+    <!-- favicon -->
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ 'assets/img/apple-touch-icon.png' | relative_url }}">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ 'assets/img/favicon-32x32.png' | relative_url }}">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ 'assets/img/favicon-16x16.png' | relative_url }}">
+    <link rel="manifest" href="{{ 'assets/img/site.webmanifest' | relative_url }}">
+    <link rel="mask-icon" href="{{ 'assets/img/safari-pinned-tab.svg' | relative_url }}" color="#{{site.theme_variables.theme_color | default: 0d6efd }}">
+    <link rel="shortcut icon" href="{{ 'assets/img/favicon.ico' | relative_url }}">
+    <!-- Schema.org metadata -->
+    {% include schemasorg.html %}
+    {%- if site.gtag and jekyll.environment == "production"%}
+    <!-- Google analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.gtag }}"></script>
+    <script> window.dataLayer = window.dataLayer || []; function gtag() { dataLayer.push(arguments); } gtag('js', new Date()); gtag('config', '{{ site.gtag }}');</script>
+    {%- endif %}
+    {%- if site.plausible and jekyll.environment == "production"%}
+    <!-- Plausible -->
+    <script defer data-domain="{{site.plausible}}" src="{{site.plausible_src | default: 'https://plausible.io/js/plausible.js'}}"></script>
+    {%- endif %}
+    {%- if site.matomo and jekyll.environment == "production"%}
+    <!-- Matomo -->
+    <script>
+        var _paq = window._paq = window._paq || [];
+        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        _paq.push(['disableCookies']);
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function() {
+        var u="{{site.matomo}}";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '{{site.matomo_id}}']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+        })();
+    </script>
+    <!-- End Matomo Code -->
+    {%- endif %}
+</head>

--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -1,0 +1,13 @@
+---
+title: "EVERSE Privacy Policy"
+description: The privacy policies for the EVERSE webpages
+---
+
+EVERSE will collect anonymised user data that helps us to monitor the
+effectiveness of our website. No personally identifiable information is recorded
+and no cookies containing such information are set in your browser session.
+
+# Analytics opt-out
+
+<div id="matomo-opt-out"></div>
+<script src="https://matomo.research.software/index.php?module=CoreAdminHome&action=optOutJS&divId=matomo-opt-out&language=auto&showIntro=1"></script>


### PR DESCRIPTION
Fixes #97.

Changes proposed in this pull request:

* Activate Matomo analytics (using the NLeSC Matomo server). This thankfully is implemented in the [elixir-toolkit-theme](https://github.com/ELIXIR-Belgium/elixir-toolkit-theme) already, so we only need to add two lines in config.yml!
* Add privacy policy. I was going to copy the one for the EVERSE main site introduced in https://github.com/EVERSE-ResearchSoftware/EVERSE-ResearchSoftware.github.io/pull/70, but may want to also take some inspiration from the RDMkit one: https://github.com/elixir-europe/rdmkit/blob/master/pages/about/privacy.md?plain=1

Notes for reviewers: 

* ~I did not add the privacy policy yet, so please don't merge yet! I opened the PR to be able to test the build on Netlify.~
* Ready for review!
