### PR TITLE
Remove citation from the template as it will be generated automatically from ETT

### DIFF
--- a/pages/your_tasks/TEMPLATE_your_tasks.md
+++ b/pages/your_tasks/TEMPLATE_your_tasks.md
@@ -56,7 +56,4 @@ If this page has been inspired or derived from other resources, make sure to ref
 There is no need to reference other relevant pages from RSQKit here - rather list them in the page's *frontmatter* 
 using parameter `related_pages` and they will be listed in the page automatically under "Related pages" section.
 
-
-## How to cite this page <!-- do not delete this heading and write your text below it -->
-Add a citation entry for this specific page, if it exists.
  


### PR DESCRIPTION
We decided to add automated support for citation in RSQKit now and then remove it once and if it is accepted in the ETT. In any case, the section on citation should be removed from the task template as it will added automatically one way or another.