### PR TITLE
Fix design-patterns-book URL

### DIFF
--- a/pages/your_tasks/readable_code.md
+++ b/pages/your_tasks/readable_code.md
@@ -104,6 +104,6 @@ functionality in custom, more error-prone code.
 [code-linters]: https://en.wikipedia.org/wiki/Lint_%28software%29
 [modular-code]: https://best-practice-and-impact.github.io/qa-of-code-guidance/modular_code.html
 [design-patterns-book]: https://refactoring.guru/design-pattern
-[design-patterns]: https://en.wikipedia.org/wiki/Software_design_pattern
+[design-patterns]: https://en.wikipedia.org/wiki/Software_design_patterns
 [code-is-read-more-than-it-is-written]: https://primalskill.blog/code-is-read-more-than-it-is-written
 


### PR DESCRIPTION
Changes proposed in this pull request:

* fix URL for design-patterns book
