### PR TITLE
Fixes #296 – add vendor to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Gemfile.lock
 .DS_Store
 .idea/
 .swp
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 .idea/
 .swp
 vendor/
+.bundle/


### PR DESCRIPTION
Fixes #296 

Changes proposed in this pull request:

* adds `vendor/` and `.bundle/` to `.gitignore`

Notes for reviewers:

* When following `INSTALL.md`, and running `bundle install`, it installs all the dependencies under `vendor/` and git still tracks all the packages. Only adding `vendor` and `bundle` to `.gitignore`.