### PR TITLE
Adding links for relevant tools to ci_cd task page

### DIFF
--- a/pages/your_tasks/ci_cd.md
+++ b/pages/your_tasks/ci_cd.md
@@ -58,13 +58,14 @@ CI/CD tools and platforms for different stages of code development and deploymen
 
 - Version Control Systems (VCS) are essential for managing code and version control. Some such tools (like GitHub, GitLab, Bitbucket)
 also provide CI/CD processes and services built around code repositories - e.g. GitHub Actions, GitLab CI/CD and BitBucket Pipelines.
+  - Additional tools such as {% tool "precommit" %} can be used alongside VCS to ensure code quality is maintained.
 - CI/CD pipelines - automate the entire process from code integration to deployment. Common tools include:
-  - GitHub Actions - integrated CI/CD directly within GitHub, with [easy-to-set-up workflows (called actions)][task_automation_github_actions].
-  - GitLab CI/CD: integrated CI/CD directly within GitLab.
+  - {% tool "github-actions" %} - integrated CI/CD directly within GitHub, with [easy-to-set-up workflows (called actions)][task_automation_github_actions].
+  - {% tool "gitlab-ci-cd" %}: integrated CI/CD directly within GitLab.
   - BitBucket Pipelines: integrated CI/CD directly within BitBucket.
-  - Jenkins: highly customisable and widely used for CI/CD pipelines.
+  - {% tool "jenkins" %}: highly customisable and widely used for CI/CD pipelines.
   - CircleCI: focuses on simplicity and speed for building and testing.
-  - Travis CI: a cloud-based CI service often used for open-source projects.
+  - {% tool "travis" %}: a cloud-based CI service often used for open-source projects.
   - Azure Pipelines: part of the Azure DevOps suite, supports various languages and platforms.
 - Testing tools - automated testing tools like JUnit, Selenium, Cypress, and Postman integrate with CI/CD workflows/pipelines to ensure the code meets quality standards.
 - Artifact repositories - tools like Artifactory or Nexus Repository store build artifacts (e.g., Docker images, binaries) for deployment.


### PR DESCRIPTION
Before creating a pull request:

- [x] *Please make sure you have checked CONTRIBUTING.md guidelines.*
- [x] *Is there a related issue for the fix you are providing? If not, please consider adding one.*
- [x] *If you are changing files in `data/` or `_includes` folder or `config.yaml` file - please make sure you have discussed this with the maintainers in the relevant issue.*
  - Not changing this

Fixes #367

Changes proposed in this pull request:

* Adding tools to the ci_cd task page
  * Github actions
  * Gitlab CI
  * Jenkins
  * precommit
  * travis ci

Notes for reviewers: 

* There may be other tools missing, these are just what was already present but not linked. 
