### PR TITLE
Remove (temporarily) ELIXIR registries column from the 'all resources table'

### DIFF
--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -1,0 +1,235 @@
+{%- if include.tag %}
+{%- assign tools = site.data.tool_and_resource_list | add_related_pages | where:"related_pages", include.tag | sort_natural: "name" %}
+{%- else %}
+{%- assign tools = site.data.tool_and_resource_list | add_related_pages | sort_natural: "name" %}
+{%- endif %}
+{%- assign tool_matches_total = 0 %}
+{%- assign country_pages = site.pages | where_exp: "item", "item.search_exclude != true" | where_exp:"item","item.national_resources != nil" %}
+{%- unless country_pages.size == 0  %}
+{%- assign query = "related_pages." | append: page.type %}
+{%- for country_page in country_pages %}
+{%- if include.tag %}
+{%- assign tool_matches = country_page.national_resources | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
+{%- unless tool_matches.size == 0 %}
+{%- assign tool_matches_total = tool_matches_total | plus: tool_matches.size %}
+{%- endunless %}
+{%- else %}
+{%- assign tool_matches_total = tool_matches_total | plus: country_page.national_resources.size %}
+{%- endif %}
+{%- endfor %}
+{%- endunless %}
+{%- unless tools.size == 0  and tool_matches_total == 0 %}
+{%- if include.tag and tools.size != 0 %}
+<a class="visually-hidden-focusable" href='#skip-tool-table'>Skip tool table</a>
+{%- if site.theme_variables.headings.resource-table-all-collapse %}
+<a data-bs-toggle="collapse" href="#tools_collapse" role="button" aria-expanded="false" aria-controls="tools_collapse" class="d-flex align-items-baseline pb-3 border-top info-collapse">
+    {%- endif %}
+    {% if site.theme_variables.headings.resource-table-all-collapse %}<h3 class="mb-0 mt-3 flex-grow-1 text-dark">{% else %}<h2 class="h2-like fs-2">{% endif %}{{site.theme_variables.headings.resource-table-all | default: 'Tools and resources on this page' }}{% if site.theme_variables.headings.resource-table-all-collapse %}</h3>{% else % %}</h2>{% endif %}
+    {%- if site.theme_variables.headings.resource-table-all-collapse %}
+    <i class="fa-solid fa-chevron-down fs-5"></i>
+</a>
+<div class="collapse info-card" id="tools_collapse">
+    {%- endif %}
+    {%- elsif tools.size == 0 and site.theme_variables.headings.resource-table-all-collapse == false or site.theme_variables.headings.resource-table-all-collapse == nil %}
+    <h2 class="h2-like fs-2">{{site.theme_variables.headings.resource-table-all | default: 'Tools and resources on this page' }}</h2>
+    {%- endif %}
+    {%- unless tools.size == 0 %}
+    <div class="table-responsive mt-4">
+        <table class="tooltable table display">
+            <thead>
+            <tr class="text-nowrap">
+                <th>Tool or resource
+                    {%- if include.tag %}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="This is a curated subset of (and not a comprehensive list of all) tools and resources on this topic - you'll typically find only the tools or resources referenced on this page.">
+                        <i class="fa-solid fa-info-circle"></i>
+                    </a>
+                    {%- endif %}
+                </th>
+                <th>Description</th>
+                <th>Related pages</th>
+<!--                <th>Registry {%- if include.tag -%}-->
+<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="Links to related information in ELIXIR registries: related policies and standards in FAIRsharing, scientific and technical descriptions of the resource in bio.tools, and related training in TeSS.">-->
+<!--                        <i class="fa-solid fa-info-circle"></i>-->
+<!--                    </a>{%- endif %}-->
+<!--                </th>-->
+            </tr>
+            </thead>
+            <tbody>
+            {%- for tool in tools %}
+            <tr>
+                {%- assign instances_tool = 0 %}
+                {%- assign query = "related_pages." | append: page.type %}
+                {%- for country_page in country_pages %}
+                {%- assign instance_matches = country_page.national_resources | where: "instance_of", tool.id | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
+                {%- unless instance_matches.size == 0 %}
+                {%- assign instances_tool = instances_tool | plus: instance_matches.size %}
+                {%- endunless %}
+                {%- endfor %}
+                {% if tool.url %}
+                <td><a href="{{tool.url}}">{{tool.name}}</a></td>
+                {%- else %}
+                <td>{{tool.name}}</td>
+                {%- endif %}
+                <td>{{tool.description}}
+                    {%- if tool.instance_of or tool.how_to_access or instances_tool != 0 != 0 and include.tag != nil %}
+                    {%- assign linked_tool = site.data.tool_and_resource_list | where:"id", tool.instance_of | first %}
+                    <div class="d-block mt-1">
+                        {%- if linked_tool %}
+                        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="This resource is an instance of {{linked_tool.name}}"><span class="badge text-primary border border-primary">{{linked_tool.name}}</span></span>
+                        {%- endif %}
+                        {%- if tool.how_to_access %}
+                        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="{{tool.how_to_access}}"><span class="badge text-primary border border-primary"> <i class="fa-solid fa-key"></i></span></span>
+                        {%- endif %}
+                        {%- unless instances_tool == 0 or include.tag == nil %}
+                        <!-- <a href="#national-resources-button">
+                        <span class="badge text-white bg-primary"><i class="fa-solid fa-arrow-circle-down me-2"></i>Different instances available</span>
+                    </a> -->
+                        {%- endunless %}
+                    </div>
+                    {%- endif %}
+                </td>
+                {%- capture related_pages %}
+                {%- for tag in tool.related_pages %}
+                {%- unless tag == page.page_id %}
+                {%- assign related_page = site.pages | where:"page_id",tag | first %}
+                <a href="{{related_page.url | relative_url }}" data-bs-toggle="tooltip" title="{{related_page.type | replace: '_', ' ' | capitalize }}"><span class="badge default-badge">{{ related_page.title | truncate: 25 }}</span></a>
+                {%- endunless %}
+                {%- endfor %}
+                {%- endcapture %}
+                <td>{{related_pages}}</td>
+<!--                <td>-->
+<!--                    {%- if tool.registry.biotools and tool.registry.biotools != "NA" %}-->
+<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="Bio.tools" href="https://bio.tools/{{tool.registry.biotools}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-info me-2"></i>Tool info</span></a>-->
+<!--                    {%- endif %}-->
+<!--                    {%- if tool.registry.fairsharing and tool.registry.fairsharing != "NA" %}-->
+<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>-->
+<!--                    {%- endif %}-->
+<!--                    {%- if tool.registry.fairsharing-coll and tool.registry.fairsharing-coll != "NA" %}-->
+<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing collection" href="https://fairsharing.org/{{tool.registry.fairsharing-coll}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>-->
+<!--                    {%- endif %}-->
+<!--                    {%- if tool.registry.tess and tool.registry.tess != "NA" %}-->
+<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="TeSS" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-graduation-cap me-2"></i>Training</span></a>-->
+<!--                    {%- endif %}-->
+<!--                    {%- if tool.registry.europmc and tool.registry.europmc != "NA" %}-->
+<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="EuroPMC" href="https://europepmc.org/article/MED/{{tool.registry.europmc}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-book me-2"></i>Publication</span></a>-->
+<!--                    {%- endif %}-->
+<!--                </td>-->
+            </tr>
+            {%- endfor %}
+            {%- if tool_matches_total == 0 or include.tag %}
+            </tbody>
+        </table>
+    </div>
+    {%- endif %}
+    {%- if include.tag %}
+    {%- if site.theme_variables.headings.resource-table-all-collapse %}
+</div>
+{%- endif %}
+<div id="skip-tool-table"></div>
+{%- endif %}
+
+{%- endunless %}
+{%- unless tool_matches_total == 0 %}
+{%- if include.tag %}
+<a class="visually-hidden-focusable" href='#skip-nat-tool-table'>Skip national tools table</a>
+{%- if site.theme_variables.headings.resource-table-all-collapse %}
+<a data-bs-toggle="collapse" href="#nat_tools_collapse" role="button" aria-expanded="false" aria-controls="nat_tools_collapse" class="d-flex align-items-baseline pb-3 border-top info-collapse">
+    {%- endif %}
+    <h3 class="{% if site.theme_variables.headings.resource-table-all-collapse %}mb-0 mt-3 flex-grow-1 text-dark {% endif %}">National resources</h3>
+    {%- if site.theme_variables.headings.resource-table-all-collapse %}
+    <i class="fa-solid fa-chevron-down fs-5"></i>
+</a>
+<div class="collapse info-card" id="nat_tools_collapse">
+    {%- endif %}
+    <p class="mt-4">Tools and resources tailored to users in different countries.</p>
+    <div class="table-responsive mt-3">
+        <table class="tooltable table display">
+            <thead>
+            <tr class="text-nowrap">
+                <th>Tool or resource
+                </th>
+                <th>Description</th>
+                <th>Related pages</th>
+<!--                <th>Registry-->
+<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="Links to related information in ELIXIR registries: related policies and standards in FAIRsharing, scientific and technical descriptions of the resource in bio.tools, and related training in TeSS.">-->
+<!--                        <i class="fa-solid fa-info-circle"></i>-->
+<!--                    </a>-->
+<!--                </th>-->
+            </tr>
+            </thead>
+            <tbody>
+            {%- endif %}
+            {%- for country_page in country_pages %}
+            {%- if include.tag %}
+            {%- assign tool_matches = country_page.national_resources | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag | sort_natural: "name" %}
+            {%- else %}
+            {%- assign tool_matches = country_page.national_resources %}
+            {%- endif %}
+            {%- for tool in tool_matches %}
+            <tr>
+                {% if tool.url %}
+                <td><a href="{{tool.url}}">{{tool.name}}</a><a href="{{country_page.url | relative_url }}" data-bs-toggle="tooltip" title="{{country_page.title}}"><span class="flag-icon ms-2 shadow-sm flag-icon-{{country_page.country_code | downcase }}"></span></a></td>
+                {%- else %}
+                <td>{{tool.name}}<a href="{{country_page.url}}"><span class="flag-icon ms-2 shadow-sm flag-icon-{{country_page.country_code | downcase }}"></span></a></td>
+                {%- endif %}
+                <td>{{tool.description | markdownify }}
+                    {%- if tool.instance_of or tool.how_to_access %}
+                    {%- assign linked_tool = site.data.tool_and_resource_list | where:"id", tool.instance_of | first %}
+                    <div class="d-block mt-1">
+                        {%- if linked_tool %}
+                        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="This resource is an instance of {{linked_tool.name}}"><span class="badge text-primary border border-primary">{{linked_tool.name}}</span></span>
+                        {%- endif %}
+                        {%- if tool.how_to_access %}
+                        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="{{tool.how_to_access}}"><span class="badge text-primary border border-primary"> <i class="fa-solid fa-key"></i></span></span>
+                        {%- endif %}
+                    </div>
+                    {%- endif %}
+                </td>
+                {%- if tool.related_pages %}
+                {%- capture related_pages %}
+                {%- for section in tool.related_pages %}
+                {%- unless section[1].size == 0 %}
+                {%- for tag in section[1] %}
+                {%- unless tag == page.page_id %}
+                {%- assign related_page = site.pages | where:"page_id",tag | first %}
+                <a class="nohover" href="{{related_page.url | relative_url }}" data-bs-toggle="tooltip" title="{{related_page.type | replace: '_', ' ' | capitalize }}"><span class="badge default-badge">{{ related_page.title | truncate: 25 }}</span></a>
+                {%- endunless %}
+                {%- endfor %}
+                {%- endunless %}
+                {%- endfor %}
+                {%- endcapture %}
+                <td>{{related_pages}}</td>
+                {%- else %}
+                <td></td>
+                {%- endif %}
+<!--                <td>-->
+<!--                    {%- if tool.registry.biotools and tool.registry.biotools != "NA" %}-->
+<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="Bio.tools" href="https://bio.tools/{{tool.registry.biotools}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-info me-2"></i>Tool info</span></a>-->
+<!--                    {%- endif %}-->
+<!--                    {%- if tool.registry.fairsharing and tool.registry.fairsharing != "NA" %}-->
+<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>-->
+<!--                    {%- endif %}-->
+<!--                    {%- if tool.registry.fairsharing-coll and tool.registry.fairsharing-coll != "NA" %}-->
+<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing collection" href="https://fairsharing.org/{{tool.registry.fairsharing-coll}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>-->
+<!--                    {%- endif %}-->
+<!--                    {%- if tool.registry.tess and tool.registry.tess != "NA" %}-->
+<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="TeSS" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-graduation-cap me-2"></i>Training</span></a>-->
+<!--                    {%- endif %}-->
+<!--                    {%- if tool.registry.europmc and tool.registry.europmc != "NA" %}-->
+<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="EuroPMC" href="https://europepmc.org/article/MED/{{tool.registry.europmc}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-book me-2"></i>Publication</span></a>-->
+<!--                    {%- endif %}-->
+<!--                </td>-->
+            </tr>
+            {%- endfor %}
+            {%- endfor %}
+            </tbody>
+        </table>
+    </div>
+    {%- if include.tag %}
+    {%- if site.theme_variables.headings.resource-table-all-collapse %}
+</div>
+{%- endif %}
+<div id="skip-nat-tool-table"></div>
+{%- endif %}
+{%- endunless %}
+{%- endunless %}


### PR DESCRIPTION
This is coming from the ELIXIR Toolkit Theme and is taking up space and not currently used in RSQKit (and not sure if it will be used in the future).