### PR TITLE
add link checker workflows

### DIFF
--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -1,0 +1,38 @@
+name: Link Checker for Pull requests
+on: pull_request
+jobs:
+  changedFiles:
+    runs-on: ubuntu-latest
+    outputs:
+      files: ${{ steps.changed-markdown-files.outputs.all_changed_files }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get changed markdown files
+        id: changed-markdown-files
+        uses: tj-actions/changed-files@v46
+        with:
+          # Avoid using single or double quotes for multiline patterns
+          files: |
+            **.md
+          matrix: true
+
+  linkChecker:
+    runs-on: ubuntu-latest
+    needs: changedFiles
+    if: ${{ needs.changedFiles.outputs.files != '' && toJSON(fromJSON(needs.changedFiles.outputs.files)) != '[]' }}
+    strategy:
+      matrix:
+        file: ${{ fromJSON(needs.changedFiles.outputs.files) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: download Lychee
+        run: |
+          wget https://github.com/lycheeverse/lychee/releases/download/lychee-v0.18.1/lychee-x86_64-unknown-linux-gnu.tar.gz
+          tar xzf lychee-x86_64-unknown-linux-gnu.tar.gz
+      - name: Check all this file's additions for broken links
+        run: |
+          export base_sha=$(git rev-parse ${{ github.sha }}^)
+          git diff -U0 ${base_sha} ${{ github.event.pull_request.head.sha }} -- ${{ matrix.file }} | grep -v "+++" | grep "^+" | cut -c 2- | ./lychee --exclude support.posit.co --exclude www.intel.com --exclude reddit.com --exclude jsfiddle.net -

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,23 @@
+name: Link Checker
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 4 * * *"
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v2
+        id: lychee
+        with:
+          # note: args has a long default value; when you override it, make sure you don't accidentally forget to include the default options you want! see https://github.com/lycheeverse/lychee-action/blob/master/action.yml
+          # note 2: the list of excluded hosts was built up for guide.esciencecenter.nl, it may need modification for RSQKit at some point
+          args: --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst' --accept '100..=103,200..=299, 429'  --exclude support.posit.co --exclude www.intel.com --exclude reddit.com --exclude jsfiddle.net
+        env:
+          # This token is included to avoid github.com requests to error out with status 429 (too many requests). It only works for GitHub requests (also other GitHub REST API calls), not for the rest of the web.
+          GITHUB_TOKEN: ${{secrets.TOKEN_GITHUB}}


### PR DESCRIPTION
Adds two workflows that check for broken links. One runs daily on all content, the other runs on PRs and then only checks the changed content in that actual PR.

Based on (i.e. 99% copied from) those of the NLeSC Guide: https://guide.esciencecenter.nl

Fixes #388.