### PR TITLE
Add training info/link to EVERSE TeSS to CI/CD task page

### DIFF
--- a/pages/contributing/metadata_guidelines.md
+++ b/pages/contributing/metadata_guidelines.md
@@ -81,15 +81,17 @@ in the "front matter" header of the page or applied to a group of pages via `_co
 * `datatable`: a boolean value indicating the activation of the pagination, sorting and searching in tabular representations of pages.
 * `related_pages`: a list of `page_id`s that are related to this page and will appear under "Related pages" section on the page, grouped by page type.
 * `page_citation`: When set to `true`, it will cause the citation section for the page to be generated in the format: "<author names>. <page title>. <site domain>. <page URL>. <date accessed>". Defaults to `true` for task pages; `false` for other page types.
-* `training`: a list of training entries, each having three properties - `name`, `registry` (which should be set to "TeSS" for EVERSE TeSS training registry) and `url` (which is a URL to TeSS search results using the keywords to match the current page).
-Training entries will show up under the "More information | Training" section on the page.
-For example: 
-    ```yml
-    training:
-        - name: Training in EVERSE TeSS
-        registry: TeSS
-        url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
-    ```
+* `training`: a list of training registry entries, each having three properties - `name`, `registry` and `url` - and taking the user to the external URL `url` within the registry that returns a certain set of training materials.
+For EVERSE TeSS training registry, the `registry` parameter should be set to "TeSS". Training registry entries will show up under the "More information | Training" section on the page.
+
+An example of a training registry entry: 
+
+```yml
+training:
+ - name: Training in EVERSE TeSS
+  registry: TeSS
+  url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
+```
 
 ## Tools and resources metadata
 

--- a/pages/contributing/metadata_guidelines.md
+++ b/pages/contributing/metadata_guidelines.md
@@ -89,8 +89,8 @@ An example of a training registry entry:
 ```yml
 training:
  - name: Training in EVERSE TeSS
-  registry: TeSS
-  url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
+    registry: TeSS
+    url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
 ```
 
 ## Tools and resources metadata

--- a/pages/contributing/metadata_guidelines.md
+++ b/pages/contributing/metadata_guidelines.md
@@ -88,9 +88,9 @@ An example of a training registry entry:
 
 ```yml
 training:
- - name: Training in EVERSE TeSS
-    registry: TeSS
-    url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
+    - name: Training in EVERSE TeSS
+      registry: TeSS
+      url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
 ```
 
 ## Tools and resources metadata

--- a/pages/contributing/metadata_guidelines.md
+++ b/pages/contributing/metadata_guidelines.md
@@ -84,13 +84,12 @@ in the "front matter" header of the page or applied to a group of pages via `_co
 * `training`: a list of training entries, each having three properties - `name`, `registry` (which should be set to "TeSS" for EVERSE TeSS training registry) and `url` (which is a URL to TeSS search results using the keywords to match the current page).
 Training entries will show up under the "More information | Training" section on the page.
 For example: 
-```yml
-training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
-```
-See [more details on formatting](https://github.com/ELIXIR-Belgium/elixir-toolkit-theme/blob/main/pages/documentation/markdown_cheat_sheet.md#listing-training-material)). 
+    ```yml
+    training:
+        - name: Training in EVERSE TeSS
+        registry: TeSS
+        url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
+    ```
 
 ## Tools and resources metadata
 

--- a/pages/contributing/metadata_guidelines.md
+++ b/pages/contributing/metadata_guidelines.md
@@ -81,8 +81,16 @@ in the "front matter" header of the page or applied to a group of pages via `_co
 * `datatable`: a boolean value indicating the activation of the pagination, sorting and searching in tabular representations of pages.
 * `related_pages`: a list of `page_id`s that are related to this page and will appear under "Related pages" section on the page, grouped by page type.
 * `page_citation`: When set to `true`, it will cause the citation section for the page to be generated in the format: "<author names>. <page title>. <site domain>. <page URL>. <date accessed>". Defaults to `true` for task pages; `false` for other page types.
-* `training`: a list of training entries, each having three properties - `name`, `registry` (which should be set to "EVERSE TeSS" - the only training registry currently supported) and `url` (see [more details on formatting](https://github.com/ELIXIR-Belgium/elixir-toolkit-theme/blob/main/pages/documentation/markdown_cheat_sheet.md#listing-training-material)). 
-Training entries will show up under the "More information / Training" section on the page.
+* `training`: a list of training entries, each having three properties - `name`, `registry` (which should be set to "TeSS" for EVERSE TeSS training registry) and `url` (which is a URL to TeSS search results using the keywords to match the current page).
+Training entries will show up under the "More information | Training" section on the page.
+For example: 
+```yml
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
+```
+See [more details on formatting](https://github.com/ELIXIR-Belgium/elixir-toolkit-theme/blob/main/pages/documentation/markdown_cheat_sheet.md#listing-training-material)). 
 
 ## Tools and resources metadata
 

--- a/pages/your_tasks/ci_cd.md
+++ b/pages/your_tasks/ci_cd.md
@@ -6,6 +6,10 @@ page_id: ci_cd
 indicators: [software_has_ci-tests]
 related_pages: 
   your_tasks: [task_automation_github_actions, task_automation_gitlab_ci_cd]
+training:
+  name: Training in EVERSE TeSS
+  registry: EVERSE TeSS
+  url: https://everse-training.app.cern.ch/materials?q=ci+cd+%22continuous+integration%22+%22continuous+deployment%22
 ---
 
 ## How can you use CI/CD in software development?

--- a/pages/your_tasks/ci_cd.md
+++ b/pages/your_tasks/ci_cd.md
@@ -7,7 +7,7 @@ indicators: [software_has_ci-tests]
 related_pages: 
   your_tasks: [task_automation_github_actions, task_automation_gitlab_ci_cd]
 training:
-  name: Training in EVERSE TeSS
+  name: EVERSE TeSS Training Registry
   registry: TeSS
   url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
 ---

--- a/pages/your_tasks/ci_cd.md
+++ b/pages/your_tasks/ci_cd.md
@@ -9,7 +9,7 @@ related_pages:
 training:
   name: Training in EVERSE TeSS
   registry: EVERSE TeSS
-  url: https://everse-training.app.cern.ch/materials?q=ci+cd+%22continuous+integration%22+%22continuous+deployment%22
+  url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
 ---
 
 ## How can you use CI/CD in software development?

--- a/pages/your_tasks/ci_cd.md
+++ b/pages/your_tasks/ci_cd.md
@@ -9,7 +9,7 @@ related_pages:
 training:
    - name: Training in EVERSE TeSS
      registry: TeSS
-     url: [https://tess.elixir-europe.org/search?q=data%20analysis](https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22)
+     url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
 ---
 
 ## How can you use CI/CD in software development?

--- a/pages/your_tasks/ci_cd.md
+++ b/pages/your_tasks/ci_cd.md
@@ -7,9 +7,9 @@ indicators: [software_has_ci-tests]
 related_pages: 
   your_tasks: [task_automation_github_actions, task_automation_gitlab_ci_cd]
 training:
-  name: EVERSE TeSS Training Registry
-  registry: TeSS
-  url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: [https://tess.elixir-europe.org/search?q=data%20analysis](https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22)
 ---
 
 ## How can you use CI/CD in software development?

--- a/pages/your_tasks/ci_cd.md
+++ b/pages/your_tasks/ci_cd.md
@@ -8,7 +8,7 @@ related_pages:
   your_tasks: [task_automation_github_actions, task_automation_gitlab_ci_cd]
 training:
   name: Training in EVERSE TeSS
-  registry: EVERSE TeSS
+  registry: TeSS
   url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
 ---
 


### PR DESCRIPTION
Add training info for one task page to show link to training materials registered in EVERSE TeSS.