### PR TITLE
Adding annotations agains tess for Deliverable D5.2

### DIFF
--- a/pages/your_tasks/citing_software.md
+++ b/pages/your_tasks/citing_software.md
@@ -6,6 +6,10 @@ page_id: citing_software
 indicators: [software_has_citation]
 related_pages:
   your_tasks: [software_identifiers, software_metadata]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22citation%22+%22cff%22
 ---
 
 ## What is software citation?
@@ -75,3 +79,6 @@ You can also use the CFFinit tool to update an existing `CITATION.cff` file by p
 
 A more detailed description on how to create `CITATION.cff` files can be found in the [Turing Way's Handbook for Open and Reproducible Research](https://book.the-turing-way.org/communication/citable/citable-cff.html). 
 You can find a list of additional tools to create, validate and convert `CITATION.cff` files in the [CFF GitHub Repository](https://github.com/citation-file-format/citation-file-format#tools-to-work-with-citationcff-files-wrench).
+
+### Training materials
+- [CodeRefinery: Software Citation guidelines](https://coderefinery.github.io/social-coding/software-citation/)

--- a/pages/your_tasks/code_review.md
+++ b/pages/your_tasks/code_review.md
@@ -6,6 +6,10 @@ page_id: code_review
 related_pages:
   your_tasks: []
 quality_indicators: [human_code_review_requirement]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22code+review%22
 ---
 
 ## Code Review in Research Software Development

--- a/pages/your_tasks/creating_good_readme.md
+++ b/pages/your_tasks/creating_good_readme.md
@@ -6,6 +6,10 @@ page_id: creating_good_readme
 related_pages:
   your_tasks: [documenting_software]
 quality_indicators: [software_has_documentation]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22readme%22
 ---
 
 ## Why is it important to have a good README file? 

--- a/pages/your_tasks/documenting_software.md
+++ b/pages/your_tasks/documenting_software.md
@@ -6,6 +6,10 @@ page_id: documenting_software
 related_pages:
   your_tasks: [writing_readable_code, documenting_software_readthedocs, creating_good_readme]
 quality_indicators: [software_has_documentation]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22documentation%22+%22readme%22+%22sphynx%22+%22readthedocs%22
 ---
 
 ## How to document your software project?

--- a/pages/your_tasks/documenting_software_readthedocs.md
+++ b/pages/your_tasks/documenting_software_readthedocs.md
@@ -6,6 +6,10 @@ page_id: documenting_software_readthedocs
 related_pages:
   your_tasks: [documenting_software]
 quality_indicators: [software_has_documentation]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22documentation%22+%22sphynx%22+%22readthedocs%22
 ---
 
 ## How to use 'Read The Docs' for your software documentation

--- a/pages/your_tasks/improving_environmental_sustainability.md
+++ b/pages/your_tasks/improving_environmental_sustainability.md
@@ -6,6 +6,10 @@ page_id: improving_environmental_sustainability
 related_pages:
   your_tasks: []
 quality_indicators: []
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22sustainability%22+%22environment%22
 ---
 
 ## How to monitor and reduce the environmental impact of my software? 

--- a/pages/your_tasks/languages_tools_infrastructures.md
+++ b/pages/your_tasks/languages_tools_infrastructures.md
@@ -6,6 +6,10 @@ page_id: languages_tools_infrastructures
 related_pages:
    your_tasks: []
 quality_indicators: []
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22r%22+%22python%22+%22c%22+%22programming+language%22+%22julia%22+%22java%22
 ---
 
 ## How to choose programming languages, tools and infrastructures?

--- a/pages/your_tasks/licensing_software.md
+++ b/pages/your_tasks/licensing_software.md
@@ -6,6 +6,10 @@ page_id: licensing_software
 related_pages:
   your_tasks: []
 quality_indicators: [software_has_license]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22license%22
 ---
 
 ## What is copyright and licensing?

--- a/pages/your_tasks/organising_software_projects.md
+++ b/pages/your_tasks/organising_software_projects.md
@@ -6,6 +6,10 @@ page_id: organising_software_projects
 related_pages:
   your_tasks: [citing_software, creating_good_readme, documenting_software, software_metadata]
 quality_indicators: []
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22organise+project%22
 ---
 
 ## Why does organising your software project matter?

--- a/pages/your_tasks/packaging_releasing_software.md
+++ b/pages/your_tasks/packaging_releasing_software.md
@@ -7,6 +7,10 @@ page_id: packaging_releasing_software
 related_pages:
   your_tasks: [releasing_software] 
 quality_indicators: [has_published_package, software_has_releases]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22package%22+%22release%22+%22pypi%22+%22github%22
 ---
 
 ## How to publish your software package to a package repository? 

--- a/pages/your_tasks/releasing_software.md
+++ b/pages/your_tasks/releasing_software.md
@@ -6,6 +6,10 @@ page_id: releasing_software
 related_pages:
   your_tasks: [software_identifiers]
 quality_indicators: [software_has_releases]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22release%22+%22github%22+%22gitlab%22
 
 ---
 

--- a/pages/your_tasks/reproducible_software_environments.md
+++ b/pages/your_tasks/reproducible_software_environments.md
@@ -6,6 +6,10 @@ page_id: reproducible_software_environments
 related_pages:
   your_tasks: []
 quality_indicators: [requirements_specified]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22reproducible%22+%22environment%22+%22docker%22+%22singularity%22+%22singularity%22+%22reproducible+environment%22+%22virtual+environment%22
 ---
 
 

--- a/pages/your_tasks/software_documentation.md
+++ b/pages/your_tasks/software_documentation.md
@@ -6,6 +6,10 @@ page_id: software_documentation
 related_pages:
   your_tasks: [documenting_software_readthedocs, creating_good_readme]
 quality_indicators: [software_has_documentation]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22documentation%22+%22code+comments%22+%22readme%22+%22mkdocs%22+%22readthedocs
 ---
 
 ## How to create good software documentation?

--- a/pages/your_tasks/software_identifiers.md
+++ b/pages/your_tasks/software_identifiers.md
@@ -6,6 +6,10 @@ page_id: software_identifiers
 related_pages:
   your_tasks: [releasing_software]
 quality_indicators: [persistent_and_unique_identifier]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22identifier%22+%22release%22+%22versioning%22
 ---
 
 

--- a/pages/your_tasks/software_metadata.md
+++ b/pages/your_tasks/software_metadata.md
@@ -6,6 +6,10 @@ page_id: software_metadata
 related_pages:
   your_tasks: [software_identifiers]
 quality_indicators: [descriptive_metadata, codemeta_completeness]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22metadata%22+%22codemeta%22+%22cff%22
 ---
 
 

--- a/pages/your_tasks/task_automation_github_actions.md
+++ b/pages/your_tasks/task_automation_github_actions.md
@@ -7,6 +7,10 @@ page_id: task_automation_github_actions
 related_pages: 
   your_tasks: [ci_cd, task_automation_gitlab_ci_cd]
 quality_indicators: [software_has_ci-tests]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22ci%2Fcd%22+%22task+automation%22+%22github%22+%22action%22
 ---
 
 ## Task automation using GitHub Actions

--- a/pages/your_tasks/task_automation_gitlab_ci_cd.md
+++ b/pages/your_tasks/task_automation_gitlab_ci_cd.md
@@ -6,6 +6,10 @@ page_id: task_automation_gitlab_ci_cd
 related_pages: 
   your_tasks: [ci_cd, task_automation_github_actions]
 quality_indicators: [software_has_ci-tests]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22ci%2Fcd%22+%22task+automation%22+%22gitlab%22
 ---
 
 ## What is GitLab CI/CD?

--- a/pages/your_tasks/testing_software.md
+++ b/pages/your_tasks/testing_software.md
@@ -6,6 +6,10 @@ page_id: testing_software
 related_pages:
   your_tasks: []
 quality_indicators: [software_has_tests, software_has_ci-tests]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22testing%22
 ---
 
 ## What is code testing?

--- a/pages/your_tasks/using_version_control.md
+++ b/pages/your_tasks/using_version_control.md
@@ -6,6 +6,10 @@ page_id: using_version_control
 related_pages:
   your_tasks: []
 quality_indicators: [version_control_use]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22version+control%22+%22git%22+%22github%22+%22gitlab%22
 ---
 
 ## How do I choose the right version control system for my research project?

--- a/pages/your_tasks/writing_readable_code.md
+++ b/pages/your_tasks/writing_readable_code.md
@@ -6,6 +6,10 @@ page_id: writing_readable_code
 related_pages:
   your_tasks: [documenting_software]
 quality_indicators: [has_no_linting_issues]
+training:
+   - name: Training in EVERSE TeSS
+     registry: TeSS
+     url: https://everse-training.app.cern.ch/materials?q=%22readable+code%22+%22robust+code%22+%22reusable+code%22
 ---
 
 


### PR DESCRIPTION
This pull request uses the annotation headers of the task pages to do searches against the tess instance that has been set up.

While the resources have not loaded, this will enable searching all the resources in the training materials repository (https://docs.google.com/spreadsheets/d/1Ufa4M024k2GeRzP9t64_P9uofXePyGRRf7LOF5vRWTg/edit?usp=sharing)