### PR TITLE
Preview option for training

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,8 @@ defaults:
       permalink: /:basename
       layout: "page"
       sidebar: main
+      training_type: link # link or preview
+      training_n_display: 3
   -
     scope:
       path: "pages/your_tasks/"
@@ -82,3 +84,6 @@ plugins:
   - jekyll-github-metadata
   - jekyll-octicons
   - jekyll-scholar
+
+training:
+  type: 

--- a/_includes/more-information-tiles.html
+++ b/_includes/more-information-tiles.html
@@ -1,0 +1,134 @@
+{%- if page.fairsharing %}
+{%- assign actual_fairsharing = nil %}
+{%- for standard in page.fairsharing %}
+{%- if standard.name %}
+{%- assign actual_fairsharing = 1 %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- if page.faircookbook %}
+{%- assign actual_faircookbook = nil %}
+{%- for recipe in page.faircookbook %}
+{%- if recipe.name %}
+{%- assign actual_faircookbook = 1 %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- if page.dsw %}
+{%- assign actual_dsw = nil %}
+{%- for question in page.dsw %}
+{%- if question.name %}
+{%- assign actual_dsw = 1 %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- if page.rdmkit %}
+{%- assign actual_rdmkit = nil %}
+{%- for rdmdoc in page.rdmkit %}
+{%- if rdmdoc.name %}
+{%- assign actual_rdmkit = 1 %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- if (page.training_type == "link" or page.training_type == "preview") and page.training %}
+{%- assign actual_training = nil %}
+{%- for training in page.training %}
+{%- if training.name %}
+{%- assign actual_training = 1 %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- if page.page_id and site.theme_variables.headings.resource-table-all-collapse%}
+{%- assign tools = site.data.tool_and_resource_list | where:"related_pages", page.page_id %}
+{%- unless tools.size == 0 %}
+{%- assign actual_tools = 1 %}
+{%- endunless %}
+{%- assign country_pages = site.pages | where_exp: "item", "item.search_exclude != true" | where_exp:"item","item.national_resources != nil" %}
+{%- unless country_pages.size == 0 %}
+{%- assign tool_matches_total = 0 %}
+{%- assign query = "related_pages." | append: page.type %}
+{%- for country_page in country_pages %}
+{%- assign tool_matches = country_page.national_resources | where_exp:"resource","resource.related_pages != nil" | where: query, page.page_id %}
+{%- assign tool_matches_total = tool_matches_total | plus: tool_matches.size %}
+{%- endfor %}
+{%- endunless %}
+{%- unless tool_matches_total == 0 %}
+{%- assign actual_nat_tools = 1 %}
+{%- endunless %}
+{%- endif %}
+{%- if actual_fairsharing or actual_faircookbook or actual_dsw or actual_rdmkit or actual_dsw or actual_training or actual_tools or actual_nat_tools %}
+<h2 class="mb-4">{{site.theme_variables.headings.more-information-tiles | default: 'More information' }}</h2>
+{%- endif %}
+
+{%- if actual_training %}
+<!-- Training -->
+<a data-bs-toggle="collapse" href="#training_collapse" role="button" aria-expanded="false" aria-controls="training_collapse" class="d-flex align-items-baseline pb-3 border-top info-collapse">
+    <h3 class="mb-0 flex-grow-1 mt-3 text-dark">Training</h3><i class="fa-solid fa-chevron-down fs-5"></i>
+</a>
+<div class="collapse info-card" id="training_collapse">
+    <div class="mt-2 p-3 pb-5">
+
+        {%- if page.training_type == "link" %}
+        <div class="row row-cols-1 row-cols-md-2 gy-2 gx-4 info-links">
+            {%- for training in page.training %}
+            <div class="col">
+                <a class="btn d-grid h-100" href="{{ training.url }}/materials?q={{ training.query | split: ' ' | join: '+' }}">
+                    <div class="row g-1">
+                        <div class="col-2 d-flex align-items-center justify-content-center">
+                            {%- assign registry = training.registry | downcase %}
+                            {%- if registry == "tess" or page.training_type == "link" %}
+                            <img alt="TeSS logo" class="img-fluid" src="{{ 'assets/img/tess_logo.svg' | relative_url }}">
+                            {%- elsif registry == "zenodo" %}
+                            <img alt="Zenodo logo" class="img-fluid" src="{{ 'assets/img/zenodo_logo.svg' | relative_url }}">
+                            {%- elsif registry == "youtube" %}
+                            <img alt="YouTube logo" class="img-fluid" src="{{ 'assets/img/youtube_logo.svg' | relative_url }}">
+                            {%- elsif registry == "carpentries" %}
+                            <img alt="Carpentries" class="img-fluid" src="{{ 'assets/img/carpentries_logo.svg' | relative_url }}">
+                            {%- elsif registry == "github" %}
+                            <i class="fa-brands fa-github text-dark fa-2xl my-3"></i>
+                            {%- else %}
+                            <i class="fa-solid fa-external-link-alt text-primary fa-lg my-3"></i>
+                            {%- endif %}
+                        </div>
+                        <div class="col-10 d-flex align-items-center">
+                            <span class="text-start">Training in {{ training.name }}</span>
+                        </div>
+                    </div>
+                </a>
+            </div>
+
+            {%- endfor %}
+        </div>
+        {%- endif %}
+
+        {%- if page.training_type == "preview" %}
+        {%- for training in page.training %}
+        <link rel="stylesheet" property="stylesheet" href="https://elixirtess.github.io/TeSS_widgets/css/tess-widget.css"/>
+        <div id="tess-widget-materials-table" class="tess-widget tess-widget-faceted-table"></div>
+        <script>
+        function initTeSSWidgets() {
+            TessWidget.Materials(document.getElementById('tess-widget-materials-table'),
+                'FacetedTable',
+                {
+                    opts: {
+                        columns: [{name: 'Name', field: 'title'},
+                            {name: 'Description', field: 'description'}],
+                        allowedFacets: ['scientific-topics', 'target-audience'],
+                        facetOptionLimit: 5
+                    },
+                    params: {
+                        pageSize: '{{ page.training_n_display }}',
+                        q: '{{ training.query }}'
+                    },
+                    baseUrl: '{{ training.url }}',
+                    instanceName: '{{ training.name }}'
+                });
+        }
+        </script>
+        <script async="" defer="" src="https://elixirtess.github.io/TeSS_widgets/js/tess-widget-standalone.js" onload="initTeSSWidgets()"></script>
+        {%- endfor %}
+        {%- endif %}
+
+    </div>
+</div>
+{%- endif %}

--- a/pages/contributing/metadata_guidelines.md
+++ b/pages/contributing/metadata_guidelines.md
@@ -81,16 +81,20 @@ in the "front matter" header of the page or applied to a group of pages via `_co
 * `datatable`: a boolean value indicating the activation of the pagination, sorting and searching in tabular representations of pages.
 * `related_pages`: a list of `page_id`s that are related to this page and will appear under "Related pages" section on the page, grouped by page type.
 * `page_citation`: When set to `true`, it will cause the citation section for the page to be generated in the format: "<author names>. <page title>. <site domain>. <page URL>. <date accessed>". Defaults to `true` for task pages; `false` for other page types.
-* `training`: a list of training registry entries, each having three properties - `name`, `registry` and `url` - and taking the user to the external URL `url` within the registry that returns a certain set of training materials.
-For EVERSE TeSS training registry, the `registry` parameter should be set to "TeSS". Training registry entries will show up under the "More information | Training" section on the page.
+* `training`:
+  * in `_config.yml`, set `training_type` to `link` to have all the training sections to display a link or to `preview` to preview TeSS training materials.
+  * if you have chosen `preview`, the `training_n_display` property sets the limit of displayed training materials
+  * the `training` object gets a list which has three properties - `name`, `url` and `query` - and taking the user to the external URL `url` within the registry that returns a certain set of training materials filtered by what is entered in `query`.
+
+Training entries will show up under the "More information | Training" section on the page.
 
 An example of a training registry entry: 
 
 ```yml
 training:
-    - name: Training in EVERSE TeSS
-      registry: TeSS
-      url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: ci cd continuous integration continuous deployment
 ```
 
 ## Tools and resources metadata

--- a/pages/your_tasks/ci_cd.md
+++ b/pages/your_tasks/ci_cd.md
@@ -7,9 +7,9 @@ indicators: [software_has_ci-tests]
 related_pages: 
   your_tasks: [task_automation_github_actions, task_automation_gitlab_ci_cd]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22ci%22+%22cd%22+%22ci%2Fcd%22+%22continuous+integration%22+%22continuous+deployment%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: ci cd continuous integration continuous deployment
 ---
 
 ## How can you use CI/CD in software development?

--- a/pages/your_tasks/citing_software.md
+++ b/pages/your_tasks/citing_software.md
@@ -7,9 +7,9 @@ indicators: [software_has_citation]
 related_pages:
   your_tasks: [software_identifiers, software_metadata]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22citation%22+%22cff%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: citation cff
 ---
 
 ## What is software citation?

--- a/pages/your_tasks/code_review.md
+++ b/pages/your_tasks/code_review.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: []
 quality_indicators: [human_code_review_requirement]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22code+review%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: code review
 ---
 
 ## Code Review in Research Software Development

--- a/pages/your_tasks/creating_good_readme.md
+++ b/pages/your_tasks/creating_good_readme.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: [documenting_software]
 quality_indicators: [software_has_documentation]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22readme%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: readme
 ---
 
 ## Why is it important to have a good README file? 

--- a/pages/your_tasks/documenting_software.md
+++ b/pages/your_tasks/documenting_software.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: [writing_readable_code, documenting_software_readthedocs, creating_good_readme]
 quality_indicators: [software_has_documentation]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22documentation%22+%22readme%22+%22sphynx%22+%22readthedocs%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: documentation readme sphynx readthedocs
 ---
 
 ## How to document your software project?

--- a/pages/your_tasks/documenting_software_readthedocs.md
+++ b/pages/your_tasks/documenting_software_readthedocs.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: [documenting_software]
 quality_indicators: [software_has_documentation]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22documentation%22+%22sphynx%22+%22readthedocs%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: documentation sphynx readthedocs
 ---
 
 ## How to use 'Read The Docs' for your software documentation

--- a/pages/your_tasks/improving_environmental_sustainability.md
+++ b/pages/your_tasks/improving_environmental_sustainability.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: []
 quality_indicators: []
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22sustainability%22+%22environment%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: sustainability environment
 ---
 
 ## How to monitor and reduce the environmental impact of my software? 

--- a/pages/your_tasks/languages_tools_infrastructures.md
+++ b/pages/your_tasks/languages_tools_infrastructures.md
@@ -7,9 +7,9 @@ related_pages:
    your_tasks: []
 quality_indicators: []
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22r%22+%22python%22+%22c%22+%22programming+language%22+%22julia%22+%22java%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: r python c programming language julia java
 ---
 
 ## How to choose programming languages, tools and infrastructures?

--- a/pages/your_tasks/licensing_software.md
+++ b/pages/your_tasks/licensing_software.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: []
 quality_indicators: [software_has_license]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22license%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: license
 ---
 
 ## What is copyright and licensing?

--- a/pages/your_tasks/organising_software_projects.md
+++ b/pages/your_tasks/organising_software_projects.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: [citing_software, creating_good_readme, documenting_software, software_metadata]
 quality_indicators: []
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22organise+project%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: organise project
 ---
 
 ## Why does organising your software project matter?

--- a/pages/your_tasks/packaging_releasing_software.md
+++ b/pages/your_tasks/packaging_releasing_software.md
@@ -8,9 +8,9 @@ related_pages:
   your_tasks: [releasing_software] 
 quality_indicators: [has_published_package, software_has_releases]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22package%22+%22release%22+%22pypi%22+%22github%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: package release pypi github
 ---
 
 ## How to publish your software package to a package repository? 

--- a/pages/your_tasks/releasing_software.md
+++ b/pages/your_tasks/releasing_software.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: [software_identifiers]
 quality_indicators: [software_has_releases]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22release%22+%22github%22+%22gitlab%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: release github% gitlab
 
 ---
 

--- a/pages/your_tasks/reproducible_software_environments.md
+++ b/pages/your_tasks/reproducible_software_environments.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: []
 quality_indicators: [requirements_specified]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22reproducible%22+%22environment%22+%22docker%22+%22singularity%22+%22singularity%22+%22reproducible+environment%22+%22virtual+environment%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: reproducible environment docker singularity singularity reproducible environment virtual environment
 ---
 
 

--- a/pages/your_tasks/software_documentation.md
+++ b/pages/your_tasks/software_documentation.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: [documenting_software_readthedocs, creating_good_readme]
 quality_indicators: [software_has_documentation]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22documentation%22+%22code+comments%22+%22readme%22+%22mkdocs%22+%22readthedocs
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: documentation code comments readme mkdocs readthedocs
 ---
 
 ## How to create good software documentation?

--- a/pages/your_tasks/software_identifiers.md
+++ b/pages/your_tasks/software_identifiers.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: [releasing_software]
 quality_indicators: [persistent_and_unique_identifier]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22identifier%22+%22release%22+%22versioning%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: identifier release versioning
 ---
 
 

--- a/pages/your_tasks/software_metadata.md
+++ b/pages/your_tasks/software_metadata.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: [software_identifiers]
 quality_indicators: [descriptive_metadata, codemeta_completeness]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22metadata%22+%22codemeta%22+%22cff%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: metadata codemeta cff
 ---
 
 

--- a/pages/your_tasks/task_automation_github_actions.md
+++ b/pages/your_tasks/task_automation_github_actions.md
@@ -8,9 +8,9 @@ related_pages:
   your_tasks: [ci_cd, task_automation_gitlab_ci_cd]
 quality_indicators: [software_has_ci-tests]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22ci%2Fcd%22+%22task+automation%22+%22github%22+%22action%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: ci cd task automation github action
 ---
 
 ## Task automation using GitHub Actions

--- a/pages/your_tasks/task_automation_gitlab_ci_cd.md
+++ b/pages/your_tasks/task_automation_gitlab_ci_cd.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: [ci_cd, task_automation_github_actions]
 quality_indicators: [software_has_ci-tests]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22ci%2Fcd%22+%22task+automation%22+%22gitlab%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query:  ci cd task automation gitlab
 ---
 
 ## What is GitLab CI/CD?

--- a/pages/your_tasks/testing_software.md
+++ b/pages/your_tasks/testing_software.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: []
 quality_indicators: [software_has_tests, software_has_ci-tests]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22testing%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: testing
 ---
 
 ## What is code testing?

--- a/pages/your_tasks/using_version_control.md
+++ b/pages/your_tasks/using_version_control.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: []
 quality_indicators: [version_control_use]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22version+control%22+%22git%22+%22github%22+%22gitlab%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: versioncontrol git github gitlab
 ---
 
 ## How do I choose the right version control system for my research project?

--- a/pages/your_tasks/writing_readable_code.md
+++ b/pages/your_tasks/writing_readable_code.md
@@ -7,9 +7,9 @@ related_pages:
   your_tasks: [documenting_software]
 quality_indicators: [has_no_linting_issues]
 training:
-   - name: Training in EVERSE TeSS
-     registry: TeSS
-     url: https://everse-training.app.cern.ch/materials?q=%22readable+code%22+%22robust+code%22+%22reusable+code%22
+   - name: EVERSE TeSS
+     url: https://everse-training.app.cern.ch
+     query: readable code robust code reusable code
 ---
 
 


### PR DESCRIPTION
Fixes #417 

Changes proposed in this pull request:

* `_config.yml` (**modified**): for `scope.path = ""`, `values.training_type` and `values.training_n_display`, the first one is either `link` or `preview`, the second one is an int between 1 and a reasonable number of training materials to be displayed.
* `_includes/more-information-tiles.html` (**added**): 
  * it checks whether `page.training_type` is `link` or `preview`
  * if `link`: displays the link. `registry == tess` has been discarded to the .md header to ease the configuration of each page (we can still add `registry: youtube` for example)
  * if `preview`: displays the preview of the n (= `training_n_display`) training materials
* `metadata_guidelines.md` (**modified**): to reflect the changes
* all `.md` using `training`: 1) I kept @dgarijo queries, simplifying them to the `query` property. 2) `registry` was discarded, it can still be used, but not shown because we are mainly redirecting to EVERSE TeSS
