### PR TITLE
Fix link checker workflow, second attempt

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           # note: args has a long default value; when you override it, make sure you don't accidentally forget to include the default options you want! see https://github.com/lycheeverse/lychee-action/blob/master/action.yml
           # note 2: the list of excluded hosts was built up for guide.esciencecenter.nl, it may need modification for RSQKit at some point
-          args: --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst' --accept '100..=103,200..=299, 429'  --exclude support.posit.co --exclude www.intel.com --exclude reddit.com --exclude jsfiddle.net
+          args: --fallback-extensions='md' --exclude-all-private --no-progress './**/*.md' --accept '100..=103,200..=299, 429' --exclude support.posit.co --exclude www.intel.com --exclude reddit.com --exclude jsfiddle.net
         env:
           # This token is included to avoid github.com requests to error out with status 429 (too many requests). It only works for GitHub requests (also other GitHub REST API calls), not for the rest of the web.
           GITHUB_TOKEN: ${{secrets.TOKEN_GITHUB}}

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           # note: args has a long default value; when you override it, make sure you don't accidentally forget to include the default options you want! see https://github.com/lycheeverse/lychee-action/blob/master/action.yml
           # note 2: the list of excluded hosts was built up for guide.esciencecenter.nl, it may need modification for RSQKit at some point
-          args: --fallback-extensions='md' --exclude-all-private --no-progress './**/*.md' --accept '100..=103,200..=299, 429' --exclude support.posit.co --exclude www.intel.com --exclude reddit.com --exclude jsfiddle.net
+          args: --fallback-extensions='md' --exclude-all-private --no-progress './**/*.md' --accept '100..=103,200..=299, 429' --exclude support.posit.co --exclude www.intel.com --exclude reddit.com --exclude jsfiddle.net --exclude 'file://'
         env:
           # This token is included to avoid github.com requests to error out with status 429 (too many requests). It only works for GitHub requests (also other GitHub REST API calls), not for the rest of the web.
           GITHUB_TOKEN: ${{secrets.TOKEN_GITHUB}}


### PR DESCRIPTION
This is an alternative to #399. It is a much more minimalist change, only adding a few options to filter problematic links instead of completely changing the workflow setup.

Most notably, it opts to skip the local links for now, because they are the main cause of the headaches. If we merge this, we should make a follow-up issue to find a better solution for local links later. Perhaps Jekyll can check such links automatically during build time?

Reviewers, please hold off on merging. Two todos: 

- [ ] I tried testing things locally, but need to test on GitHub as well to make sure everything works (notably the use of the GitHub token that should prevent a bunch of failures).
- [ ] I still need to do the PR link checker workflow as well, only did the full site link checker workflow for now.