### PR TITLE
CI tweaks

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -2,8 +2,9 @@ name: Jekyll site CI
 
 on:
   push:
+    branches: [ main ]
   pull_request:
-    branches: [ master, main ]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:
@@ -16,20 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.inputs.branch }}
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
-          bundler-cache: true
-          cache-version: 0
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
 
       - name: Set Jekyll environment
         id: name
@@ -42,10 +40,6 @@ jobs:
         env:
           REPO_OWNER: ${{ github.repository_owner }}
 
-      - name: Install dependencies
-        run: |
-          bundle install
-        
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -51,6 +51,9 @@ jobs:
 
       - name: Run discrepancy check script
         run: python _scripts/compare_rsqkit_techradar_tools.py
+        env:
+          # This token is included to avoid github.com requests to error out with status 429 (too many requests). It only works for GitHub requests (also other GitHub REST API calls), not for the rest of the web.
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default

--- a/_scripts/compare_rsqkit_techradar_tools.py
+++ b/_scripts/compare_rsqkit_techradar_tools.py
@@ -27,17 +27,17 @@ def load_yaml_tools_from_rsqkit():
             print("YAML content is not a list")
     return tools
 
-def load_jsonld_tools_from_techradar():
+def load_jsonld_tools_from_techradar(requests_headers=None):
     tools = {}
     JSON_MATCH_FIELD = "schema:description" 
-    response = requests.get(TECHRADAR_GITHUB_API_URL)
+    response = requests.get(TECHRADAR_GITHUB_API_URL, headers=requests_headers)
     response.raise_for_status()
     files = response.json()
 
     for file in files:
         if file["name"].endswith(".json"):
             raw_url = file["download_url"]
-            file_response = requests.get(raw_url)
+            file_response = requests.get(raw_url, headers=requests_headers)
             file_response.raise_for_status()
             data = json.loads(file_response.text)
             if JSON_MATCH_FIELD in data:
@@ -96,7 +96,15 @@ def summarize_discrepancies(discrepancy_dict):
 
 def main():
     rsqkit_tools = load_yaml_tools_from_rsqkit()
-    techradar_tools = load_jsonld_tools_from_techradar()
+
+    bearer_token = os.getenv("GITHUB_TOKEN")
+
+    if bearer_token is not None:
+        requests_headers = {"Authorization": f"Bearer {bearer_token}"}
+    else:
+        requests_headers = None
+
+    techradar_tools = load_jsonld_tools_from_techradar(requests_headers=requests_headers)
 
     FIELDS_TO_COMPARE = ["description"]
     FIELD_MAPPING = {


### PR DESCRIPTION
In #399, I made some additional changes that were either necessary or opportune because I was working on the files anyway but that were not directly related to the purpose of the PR itself (fixing the link checker). Now that #399 is superceded by #431, the two additional changes from #399 can now be contributed separately. That is what this PR does. The two changes are:

- Update and streamlining of the existing Jekyll build job (e.g. it installed Ruby bundle dependencies twice)
- Added GITHUB_TOKEN authentication to the Techradar comparison Python script. This solves the issue I saw appearing in one of the CI runs that we run out of GitHub API calls due to request throttling. @shraddha-bajare