### PR TITLE
Dockerfile and docker-compose.yml improvements - #455

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.3.7
 WORKDIR /usr/src/app
 RUN gem install bundler jekyll
-COPY . .
+COPY Gemfile* ./
 RUN bundle install
 EXPOSE 4000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,6 @@ services:
     ports:
       - "4000:4000"
     volumes:
-      - .:/usr/src/app
+      - .:/usr/src/site:Z
+    working_dir: /usr/src/site
     command: bundle exec jekyll serve --host 0.0.0.0 --port 4000 --watch --force_polling


### PR DESCRIPTION
Fixes #455.

Changes proposed in this pull request:

* Reduces the amount of source copied into the image created from the Dockerfile by only including Gemfile*
* Changes the mountpoint specified by the docker-compose.yml to avoid potential masking the same directory
* Adds the :Z option to help with SELinux details
* Changes the working directory in the docker-compose.yml to match the new mountpoint

Notes for reviewers: 

* I understand the issues I saw may not affect all systems but hopefully this extends the number of platforms it will work for. I have not tested this beyond Fedora 42 and so unfortunately it would make sense for there to be some further testing to confirm that this doesn't break anyone else's workflows.
