### PR TITLE
Add csv gem as an external dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'jekyll', '~> 4.3.1'
 gem 'jemoji', '~> 0.13.0'
 gem 'kramdown-parser-gfm', '~> 1.1'
 gem 'jekyll-octicons'
+gem 'csv'
 
 group :jekyll_plugins do
   gem 'jekyll-redirect-from', '~> 0.16.0'


### PR DESCRIPTION
As of Ruby 3.4.0 - csv library needs to be added as an external dependency otherwise the following error is being thrown:

```bash
/Users/user/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/jekyll-4.3.4/lib/jekyll.rb:28: warning: csv was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add csv to your Gemfile or gemspec to silence this warning.
bundler: failed to load command: jekyll (/Users/user/.rbenv/versions/3.4.1/bin/jekyll)
```