### PR TITLE
Add new parameter to sort menu items

### DIFF
--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -82,6 +82,7 @@ subitems:
     description: Guidelines and solutions for tackling common software tasks
     url: /tasks
     image_url: /assets/img/flaticon/checklist.png
+    sort: alphabetical
     subitems:
       - title: "Choosing languages, tools & infrastructures"
         url: /languages_tools_infrastructures


### PR DESCRIPTION
This PR adds a new sort parameter to menu items to enforce alphabetical sort on items but only where needed. At other times - the order in which items are added to the config/data files should be respected.