### PR TITLE
Fix URLs in main.yml sidebar entries

### DIFF
--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -82,25 +82,25 @@ subitems:
       - title: "Software identifiers"
         url: /software_identifiers
       - title: "Software documentation"
-        url: software_documentation
+        url: /software_documentation
       - title: "Documenting software project"
-        url: documenting_software_project
+        url: /documenting_software_project
       - title: "Documenting code"
-        url: documenting_code
+        url: /documenting_code
       - title: "Creating a good README"
         url: /creating_good_readme
       - title: "Software metadata"
-        url: software_metadata
+        url: /software_metadata
       - title: "Packaging software"
-        url: packaging_software
+        url: /packaging_software
       - title: "Releasing software"
-        url: releasing_software
+        url: /releasing_software
       - title: "Archiving software"
-        url: archiving_software
+        url: /archiving_software
       - title: "Publishing software"
         url: /publishing_software
       - title: "Computational workflows"
-        url: computational_workflows
+        url: /computational_workflows
       - title: CI/CD
         url: /ci_cd
         subitems:


### PR DESCRIPTION
This pull request makes a small but important update to the sidebar navigation in `_data/sidebars/main.yml`. The change standardizes the URLs for several sidebar items by adding a leading slash, ensuring consistency and proper routing throughout the site.

this will close #462 