### PR TITLE
Remove license from CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,3 +21,4 @@ keywords:
   - RSE
 version: v1.0.0
 date-released: '2025-02-25'
+license-url: "https://github.com/EVERSE-ResearchSoftware/RSQKit/blob/main/LICENSE.md"


### PR DESCRIPTION
We have a more complex licensing process for the repo which is explained in LICENSE.md. Apache 2.0 was never used for code - we always used MIT license.

I suggest removing the license info from CITATION.cff.
Fixes #608.