### PR TITLE
Template layout fix for tool/domain-specific pages

### DIFF
--- a/pages/tasks/TEMPLATE_task.md
+++ b/pages/tasks/TEMPLATE_task.md
@@ -67,12 +67,11 @@ The RSQKit Editorial Board applies these principles when reviewing task pages; f
 
 ### Solutions 
 
-
-## Tool or domain specific tasks <!-- OPTIONAL (remove this till end of page if not needed) -->
-
-<!--
-Use this section to list tool or domain specific (sub-)tasks. List the pages in the `child_pages:` attribute in the page metadata. Then uncomment the following, including it in the page:
-
 {% assign child_pages = page.child_pages | join: ', ' %}
-{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=4 %}
--->
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}

--- a/pages/tasks/archiving_software.md
+++ b/pages/tasks/archiving_software.md
@@ -61,6 +61,16 @@ Software archiving is now a foundational component of digital research infrastru
 As the scientific community moves toward open, reproducible, and [FAIR (Findable, Accessible, Interoperable, Reusable) principles][fair_rs], robust software preservation practices are essential. 
 Researchers must adopt workflows and tools that not only produce results but also ensure those results can be trusted and reused decades from now.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
+
+
 [fair_rs]: fair_rs.md
 [software_metadata]: ./software_metadata
 [documenting_software]: ./software_documentation

--- a/pages/tasks/ci_cd.md
+++ b/pages/tasks/ci_cd.md
@@ -72,12 +72,14 @@ CI/CD tools and platforms for different stages of code development and deploymen
 - Monitoring - tools like Prometheus, Grafana, and New Relic are used for real-time monitoring in production to ensure system health.
 - Infrastructure as Code (IaC) - tools like {% tool "terraform" %}, {% tool "vagrant" %} or {% tool "ansible" %} automate infrastructure provisioning and configuration, ensuring consistency across environments.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
 ## Tool- or Domain-Specific Tasks
 
 This is a suggested list tool-specific sub-tasks to have a look at.
 
-{% assign child_pages = page.child_pages | join: ', ' %}
-{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=4 %}
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
 
 [task_automation_github_actions]: ./task_automation_github_actions
 [task_automation_gitlab_ci_cd]: ./task_automation_gitlab_ci_cd

--- a/pages/tasks/citing_software.md
+++ b/pages/tasks/citing_software.md
@@ -72,3 +72,12 @@ You can also use the `CFFinit` tool to update an existing `CITATION.cff` file by
 
 A more detailed description on how to create `CITATION.cff` files can be found in the [Turing Way's Handbook for Open and Reproducible Research](https://book.the-turing-way.org/communication/citable/citable-cff.html).
 You can find a list of additional tools to create, validate and convert `CITATION.cff` files in the [CFF GitHub Repository](https://github.com/citation-file-format/citation-file-format#tools-to-work-with-citationcff-files-wrench).
+
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}

--- a/pages/tasks/code_review.md
+++ b/pages/tasks/code_review.md
@@ -71,3 +71,12 @@ Tools that can help:
 Initiatives:
 
 - [CODECHECK](https://codecheck.org.uk/) aims to tackle the challenge of supporting codecheckers in computational science with a workflow, guidelines and tools to evaluate computer programs underlying scientific papers.
+
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}

--- a/pages/tasks/complete_bibliographic_metadata_codemeta.md
+++ b/pages/tasks/complete_bibliographic_metadata_codemeta.md
@@ -107,3 +107,11 @@ Here's a sample `codemeta.json` file to get you started:
 ```
 By following these steps, you can provide complete bibliographic metadata for your software project in a CodeMeta file, enhancing its discoverability and citation.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}

--- a/pages/tasks/computational_workflows.md
+++ b/pages/tasks/computational_workflows.md
@@ -117,6 +117,15 @@ It can maximise their quality and value as research assets and facilitate their 
 
 The[ Workflows Community Initiative’s FAIR Workflows Working Group (WCI-FW)][WCI-FW], a global and open community of researchers and developers working with computational workflows across disciplines and domains, has systematically addressed the application of both FAIR data and software principles to computational workflows.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
+
 [apache-airflow-dag]: https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dags.html
 [cwl]: https://www.commonwl.org/
 [wdl]: https://openwdl.org/

--- a/pages/tasks/creating_good_readme.md
+++ b/pages/tasks/creating_good_readme.md
@@ -151,6 +151,16 @@ For more information, see [our guidelines](https://everse.software/RSQKit/licens
 {% tool "somef" %} is a [tool to automatically extract information (metadata) from README files][somef-paper].
 It is not an assessment tool for README files, but can be used for detecting missing parts of a README file.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
+
+
 [documenting_software]: ./documenting_software
 [README-best-practices]: https://tilburgsciencehub.com/topics/collaborate-share/share-your-work/content-creation/readme-best-practices/
 [readme-guidelines]: https://data.4tu.nl/s/documents/Guidelines_for_creating_a_README_file.pdf

--- a/pages/tasks/documenting_code.md
+++ b/pages/tasks/documenting_code.md
@@ -4,7 +4,7 @@ description: How to write technical documentation to explain to other developers
 contributors: ["Azza Gamgami", "Aleksandra Nenadic", "Laura Portell-Silva"]
 page_id: documenting_code
 related_pages:
-  tasks: [documenting_software_project, writing_readable_code, creating_good_readme]
+  tasks: [documenting_software_project, writing_readable_code, creating_good_readme, licensing_software]
 child_pages: [documenting_software_readthedocs]
 quality_indicators: [software_has_documentation]
 keywords: ["documentation", "code documentation"]
@@ -141,12 +141,14 @@ While no software can completely write software documentation for you, several t
 * Leverage CI/DC tools, offered by platforms such as {% tool "github" %} and {% tool "gitlab" %} to automate quality assurance and release of your updated documentation to the public. For example, take a look at the [GitHub actions in the RSQKit repository](https://github.com/EVERSE-ResearchSoftware/RSQKit/actions) 
 for some automated tasks.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
 ## Tool- or Domain-Specific Tasks
 
 This is a suggested list tool-specific sub-tasks to have a look at.
 
-{% assign child_pages = page.child_pages | join: ', ' %}
 {% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
 
 [documenting_software_project]: ./documenting_software_project
 [creating_good_readme]: ./creating_good_readme

--- a/pages/tasks/documenting_software_project.md
+++ b/pages/tasks/documenting_software_project.md
@@ -54,6 +54,15 @@ See more on [how to cite your software project][citing_software].
 - Roadmap - an overview of the current and future development plans and milestones (this can also be a pointer to your issue tracker, e.g. in GitHub).
 - Changelog and release notes - a text file that contains a record of what notable changes are made between versions of software.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
+
 [open-api]: https://swagger.io/specification/
 [click]: https://click.palletsprojects.com/en/stable/
 [magicblast]: https://ncbi.github.io/magicblast/

--- a/pages/tasks/documenting_software_readthedocs.md
+++ b/pages/tasks/documenting_software_readthedocs.md
@@ -128,5 +128,14 @@ After a successful build, the documentation will be published and publicly acces
 For further information, please refer to the [Read the Docs tutorial][readthedocs-tutorial].
 Additionally, check out the [RSQKit page on documenting code][documenting_code] for more insights.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
+
 [readthedocs-tutorial]: https://docs.readthedocs.io/en/stable/tutorial/index.html
 [documenting_code]: ./documenting_code

--- a/pages/tasks/fair_rs.md
+++ b/pages/tasks/fair_rs.md
@@ -86,6 +86,15 @@ Their role is to make quality aspects visible, help researchers identify strengt
 In the context of research software, such assessments are diagnostic rather than evaluative — they guide reflection, transparency, and learning, not scoring or ranking. 
 By using them, researchers can better understand how their software performs across different aspects of FAIRness and make informed decisions about how to improve it.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
+
 [awesome-rs-registries]: https://github.com/NLeSC/awesome-research-software-registries
 [biotools]: https://bio.tools
 [cff]: https://citation-file-format.github.io/

--- a/pages/tasks/improving_environmental_sustainability.md
+++ b/pages/tasks/improving_environmental_sustainability.md
@@ -64,3 +64,12 @@ Similarly, the [GREENER software principles](https://www.nature.com/articles/s43
 * {% tool "carbontracker" %} is a tool that monitors and predicts energy and carbon footprint for training machine learning models.
 * {% tool "greenspectorstudio" %} measures energy usage and resource efficiency in web and mobile applications.
 * {% tool "ecograder" %} evaluates website sustainability based on design and operational efficiency.
+
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}

--- a/pages/tasks/languages_tools_infrastructures.md
+++ b/pages/tasks/languages_tools_infrastructures.md
@@ -72,7 +72,6 @@ We highlight three typical cases, related loosely to the [three tiers of researc
    However, the reason for you joining the project may be exactly to apply some new technology, possibly using some existing framework.
    In such cases the above social considerations would apply, but you will still be constrained in your choices by the existing languages or frameworks in the project.
 
-
 ### Good default languages 
 
 What follows is a somewhat opinionated list of good starting choices of programming languages for research software engineering projects.
@@ -117,5 +116,14 @@ Some interesting templates to consider for research software:
 - [BestieTemplate.jl](https://github.com/JuliaBesties/BestieTemplate.jl): Julia package template for research software
 - For R, the [usethis](https://usethis.r-lib.org) package provides a good basis for developing R packages.
 - RSQKit itself also uses templates to create pages, like [the one used for this task page](https://github.com/EVERSE-ResearchSoftware/RSQKit/blob/main/pages/tasks/TEMPLATE_task.md).
+
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
 
 [nesc-rs-guide]: https://guide.esciencecenter.nl/

--- a/pages/tasks/licensing_software.md
+++ b/pages/tasks/licensing_software.md
@@ -170,6 +170,15 @@ Otherwise, create a new file called, e.g. LICENSE, in the root directory to your
 * See RSQKit's [LICENSE file][rsqkit-licence] that specifies different licences for metadata, content and software. 
 * In case you want or need to apply licenses one a per file bases, have a look at {% tool "reuse" %}.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
+
 [spdx-licences]: https://spdx.org/licenses/
 [fair-rs-principles]: https://doi.org/10.15497/RDA00068
 [cc0]: https://creativecommons.org/publicdomain/zero/1.0/

--- a/pages/tasks/organising_software_projects.md
+++ b/pages/tasks/organising_software_projects.md
@@ -110,6 +110,15 @@ project_name/
 
 For best practices and guidance for designing research projects in particular focused on data - check out [the Turing Way Project's Guide for project design][turing-project-design].
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
+
 [creating_good_readme]: ./creating_good_readme
 [licensing_software]: ./licensing_software
 [releasing_code]: ./releasing_software

--- a/pages/tasks/packaging_software.md
+++ b/pages/tasks/packaging_software.md
@@ -80,6 +80,15 @@ Container and workflow registries allow you to:
 * package and share ready-to-run code and environments – users can pull and run a container with no manual setup.
 * versioned distribution – each container or workflow can have tagged versions, just like source code releases.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
+
 [publishing_software]: ./publishing_software
 [releasing_software]: ./releasing_software
 [python-package-github]: https://medium.com/@thomas.vidori/how-to-create-a-python-package-and-publish-it-on-github-eebc78b2a12d

--- a/pages/tasks/publishing_software.md
+++ b/pages/tasks/publishing_software.md
@@ -25,4 +25,5 @@ Tasks to consider when publishing your software include:
 This is the suggested order in which you should look at the related sub-tasks.
 
 {% assign child_pages = page.child_pages | join: ', ' %}
-{% include section-navigation-tiles.html type="tasks" custom=child_pages training=false sort=false col=3 %}
+{% include section-navigation-tiles.html type="tasks" custom=child_pages training=false sort=false col=2 %}
+

--- a/pages/tasks/releasing_software.md
+++ b/pages/tasks/releasing_software.md
@@ -39,5 +39,13 @@ For example, to create a software release on GitHub:
 - Click on `Publish release`.
 - If your repository is integrated with Zenodo - a new [DOI][software_identifiers] for this software release will automatically be issued by {% tool "zenodo" %}.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
 
 [software_identifiers]: ./software_identifiers

--- a/pages/tasks/reproducible_software_environments.md
+++ b/pages/tasks/reproducible_software_environments.md
@@ -111,6 +111,15 @@ Not using virtual environments at all and mixing different tools to manage them 
 
 Decide on a package manager and a virtual environment management tool for your programming language and start using them.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
+
 [pip-venv]: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/
 [fair-rs]: https://carpentries-incubator.github.io/fair-research-software
 [intermediate-rs-dev]: https://carpentries-incubator.github.io/python-intermediate-development/

--- a/pages/tasks/software_documentation.md
+++ b/pages/tasks/software_documentation.md
@@ -25,4 +25,5 @@ This includes, for example, comments, docstrings, software architecture and API 
 Both levels are important: project documentation helps people use and adopt your software, while code documentation helps people develop and sustain it.
 
 {% assign child_pages = page.child_pages | join: ', ' %}
-{% include section-navigation-tiles.html type="tasks" custom=child_pages training=false sort=false col=3 %}
+{% include section-navigation-tiles.html type="tasks" custom=child_pages training=false sort=false col=2 %}
+

--- a/pages/tasks/software_identifiers.md
+++ b/pages/tasks/software_identifiers.md
@@ -141,6 +141,14 @@ You can see the Zenodo DOI badge under `Details`:
 
 ![Badge in a software repository](../../images/badge_in_repo.png)
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
 
 [calver]: https://calver.org/
 [citable-github-ssi]: https://www.software.ac.uk/blog/making-code-citable-zenodo-and-github

--- a/pages/tasks/software_management_planning.md
+++ b/pages/tasks/software_management_planning.md
@@ -45,3 +45,12 @@ Before choosing an SMP solution, it is important to recognise that **different p
 - [Netherlands eScience Center Practical Guide to SMPs](https://doi.org/10.5281/zenodo.7589725): A detailed, practitioner-focused guide offering examples and recommendations for creating effective SMPs in computational research projects.
 - [Wellcome Trust Outputs Management Plans](https://wellcome.org/research-funding/guidance/prepare-to-apply/how-complete-outputs-management-plan): Although broader in scope, these plans include requirements relevant to software outputs and can inform funding-aligned SMP development. This approach seems to be adopted by several funders to cover diversity of research outputs.
 - [forschungsdaten.info Software Management Plans](http://forschungsdaten.info): A guide summarising what an SMP should contain (administrative & technical info, software description, QA, maintenance & sharing, legal/ethical aspects, user support, costs and responsibilities).
+
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}

--- a/pages/tasks/software_metadata.md
+++ b/pages/tasks/software_metadata.md
@@ -94,9 +94,11 @@ Alternatively, {% tool "somefvider" %} will allow you to download auto-generated
 Using CodeMeta file to describe your software will propagate between different archival infrastructures, platforms and services which understand CodeMeta descriptions and can ingest existing `codemeta.json` files automatically ({% tool "zenodo" %}, {% tool "figshare" %}, {% tool "inveniordm" %} and {% tool "softwareheritage" %}).
 This means you will not have to duplicate the work when using such services - e.g. when [obtaining a DOI for your software](./software_identifiers), if you have `codemeta.json` file already you will not have to fill in the corresponding software metadata again.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
 ## Tool- or Domain-Specific Tasks
 
 This is a suggested list tool-specific sub-tasks to have a look at.
 
-{% assign child_pages = page.child_pages | join: ', ' %}
-{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=4 %}
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}

--- a/pages/tasks/testing_software.md
+++ b/pages/tasks/testing_software.md
@@ -232,6 +232,15 @@ Here are a few examples of these principles:
   - Continuous Integration is the process of continuously integrating code into the mainline of your code developments and thereby automate the build of the software as well as the tests the software in so-called Continuous Integration pipelines.
   - Continuous Integration automates repetitive tests, saves time and ensures tests are run consistently across different environments and platforms.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
+
 [software-testing]: https://en.wikipedia.org/wiki/Software_testing
 [software-quality-assurance]: https://en.wikipedia.org/wiki/Software_quality_assurance
 [software-testing-tactics]: https://en.wikipedia.org/wiki/Software_testing_tactics

--- a/pages/tasks/using_containers.md
+++ b/pages/tasks/using_containers.md
@@ -4,7 +4,7 @@ description: Why and how to use containers for research software development?
 contributors: ["Shraddha Bajare"]
 page_id: using_containers
 related_pages: 
-  your_tasks: [ci_cd]
+  tasks: [ci_cd]
 keywords: ["containers", "docker", "apptainer", "software packaging", "reproducibility", "portability", "containerization", "software deployment"]
 training:
   - name: "EVERSE TeSS"
@@ -128,11 +128,18 @@ pytest:
       - apptainer exec my-container-v1.0.0.sif python -m unittest discover tests/
 ```
 
-**Note:**  
+**Note:** 
 Apptainer generally does not support port mapping like Docker.  
 For networked services, Docker is usually preferred.
 
-## References
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
 
 [Docker documentation]: https://docs.docker.com/get-started/docker-overview/
 [Docker reference docs for CLI, APIs, and platform behaviors]: https://docs.docker.com/reference/

--- a/pages/tasks/using_version_control.md
+++ b/pages/tasks/using_version_control.md
@@ -77,3 +77,12 @@ Implementing version control in a research context involves more than just choos
 * Maintain your repository:
    * Regularly backup your repository
    * Periodically clean up old branches and review access permissions
+
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}

--- a/pages/tasks/writing_readable_code.md
+++ b/pages/tasks/writing_readable_code.md
@@ -84,6 +84,15 @@ have built-in support for checking conformance to style conventions and they wil
 - Use existing and well-tested libraries or packages for common functionality and tasks (e.g. reading and writing data in standard formats) to avoid duplication and reimplementing
 functionality in custom, more error-prone code.
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
+
 [ssi]: https://www.software.ac.uk/
 [fair-rs-principles]: https://www.nature.com/articles/s41597-022-01710-x
 [intermediate-rs-dev]: https://carpentries-incubator.github.io/python-intermediate-development/

--- a/pages/tasks/writing_research_software_stories.md
+++ b/pages/tasks/writing_research_software_stories.md
@@ -188,3 +188,12 @@ Lastly, an example Research Software Story created using this approach can be fo
 
 * [GreenPhysECS research software story](https://everse.software/RSQKit/greenphsecs_research_software_story)
 
+{% assign child_pages = page.child_pages | join: ', ' %}
+{% if child_pages != null and child_pages != '' %}
+## Tool- or Domain-Specific Tasks
+
+This is a suggested list tool-specific sub-tasks to have a look at.
+
+{% include section-navigation-tiles.html type="tasks" custom=child_pages sort=false col=2 %}
+{% endif %}
+


### PR DESCRIPTION
A bit of infrastructure tidy-up:

- Aligning the layout of the tool/domain-specific pages (they are now displayed as tiles in 2 columns to align with related pages for consistency).
- Also added a check for existence of child pages and then copy pasted this bit of template to all task pages.

