### PR TITLE
Added RSFC to "Tools and practices for FAIR" section in RSQKit website

### DIFF
--- a/_data/quality_dimensions.yml
+++ b/_data/quality_dimensions.yml
@@ -1,1 +1,420 @@
-[]
+-   abbreviation: compatibility
+    description: 'Degree to which a product, system or component can exchange information
+        with other products, systems or components, and/or perform its required functions
+        while sharing the same common environment and resources. This characteristic
+        is composed of the following sub-characteristics:
+
+
+        **Co-existence**
+
+
+        Degree to which a product can perform its required functions efficiently while
+        sharing a common environment and resources with other products, without detrimental
+        impact on any other product.
+
+
+        **Interoperability**
+
+
+        Degree to which a system, product or component can exchange information with
+        other products and mutually use the information that has been exchanged.'
+    identifier: https://w3id.org/everse/i/dimensions/compatibility
+    name: Compatibility
+    source:
+        name: ISO/IEC 25010 standard
+        url: https://iso25000.com/index.php/en/iso-25000-standards/iso-25010
+-   abbreviation: fairness
+    description: 'FAIRness refers to the degree to which research software adheres
+        to the FAIR principles: Findable, Accessible, Interoperable, and Reusable.
+        These principles, adapted for research software, aim to enhance the discoverability,
+        accessibility, interoperability, and reusability of software, thereby maximizing
+        its value and impact in scientific research.'
+    identifier: https://w3id.org/everse/i/dimensions/fairness
+    name: FAIRness
+    source:
+        name: Introducing the FAIR Principles for research software
+        url: https://www.nature.com/articles/s41597-022-01710-x
+-   abbreviation: flexibility
+    description: 'Degree to which a product can be adapted to changes in its requirements,
+        contexts of use or system environment. This characteristic is composed of
+        the following sub-characteristics:
+
+
+        **Adaptability**
+
+
+        Degree to which a product or system can effectively and efficiently be adapted
+        for or transferred to different hardware, software or other operational or
+        usage environments.
+
+
+        **Scalability**
+
+
+        Degree to which a product can handle growing or shrinking workloads or to
+        adapt its capacity to handle variability.
+
+
+        **Installability**
+
+
+        Degree of effectiveness and efficiency with which a product or system can
+        be successfully installed and/or uninstalled in a specified environment.
+
+
+        **Replaceability**
+
+
+        Degree to which a product can replace another specified software product for
+        the same purpose in the same environment.'
+    identifier: https://w3id.org/everse/i/dimensions/flexibility
+    name: Flexibility
+    source:
+        name: ISO/IEC 25010 standard
+        url: https://iso25000.com/index.php/en/iso-25000-standards/iso-25010
+-   abbreviation: functional_suitability
+    created: 03-04-2025
+    description: 'This characteristic represents the degree to which a product or
+        system provides functions that meet stated and implied needs when used under
+        specified conditions. This characteristic is composed of the following sub-characteristics:
+
+
+        **Functional completeness**
+
+
+        Degree to which the set of functions covers all the specified tasks and intended
+        users'' objectives.
+
+
+        **Functional correctness**
+
+
+        Degree to which a product or system provides accurate results when used by
+        intended users.
+
+
+        **Functional appropriateness**
+
+
+        Degree to which the functions facilitate the accomplishment of specified tasks
+        and objectives.'
+    identifier: https://w3id.org/everse/i/dimensions/functional_suitability
+    name: Functional suitability
+    source:
+        name: ISO/IEC 25010 standard
+        url: https://iso25000.com/index.php/en/iso-25000-standards/iso-25010
+-   abbreviation: interaction_capability
+    description: 'Degree to which a product or system can be interacted with by specified
+        users to exchange information via the user interface to complete specific
+        tasks in a variety of contexts of use. This characteristic is composed of
+        the following sub-characteristics:
+
+
+        **Appropriateness recognizability**
+
+
+        Degree to which users can recognize whether a product or system is appropriate
+        for their needs.
+
+
+        **Learnability**
+
+
+        Degree to which the functions of a product or system can be learnt to be used
+        by specified users within a specified amount of time.
+
+
+        **Operability**
+
+
+        Degree to which a product or system has attributes that make it easy to operate
+        and control.
+
+
+        **User error protection**
+
+
+        Degree to which a system prevents users against operation errors.
+
+
+        **User engagement**
+
+
+        Degree to which a user interface presents functions and information in an
+        inviting and motivating manner encouraging continued interaction.
+
+
+        **Inclusivity**
+
+
+        Degree to which a product or system can be used by people of various backgrounds
+        (such as people of various ages, abilities, cultures, ethnicities, languages,
+        genders, economic situations, etc.).
+
+
+        **User assistance**
+
+
+        Degree to which a product can be used by people with the widest range of characteristics
+        and capabilities to achieve specified goals in a specified context of use.
+
+
+        **Self-descriptiveness**
+
+
+        Degree to which a product presents appropriate information, where needed by
+        the user, to make its capabilities and use immediately obvious to the user
+        without excessive interactions with a product or other resources (such as
+        user documentation, help desks or other users).'
+    identifier: https://w3id.org/everse/i/dimensions/interaction_capability
+    name: Interaction Capability
+    source:
+        name: ISO/IEC 25010 standard
+        url: https://iso25000.com/index.php/en/iso-25000-standards/iso-25010
+-   abbreviation: maintainability
+    description: 'This characteristic represents the degree of effectiveness and efficiency
+        with which a product or system can be modified to improve it, correct it or
+        adapt it to changes in environment, and in requirements. This characteristic
+        is composed of the following sub-characteristics:
+
+
+        **Modularity**
+
+
+        Degree to which a system or computer program is composed of discrete components
+        such that a change to one component has minimal impact on other components.
+
+
+        **Reusability**
+
+
+        Degree to which a product can be used as an asset in more than one system,
+        or in building other assets.
+
+
+        **Analysability**
+
+
+        Degree of effectiveness and efficiency with which it is possible to assess
+        the impact on a product or system of an intended change to one or more of
+        its parts, to diagnose a product for deficiencies or causes of failures, or
+        to identify parts to be modified.
+
+
+        **Modifiability**
+
+
+        Degree to which a product or system can be effectively and efficiently modified
+        without introducing defects or degrading existing product quality.
+
+
+        **Testability**
+
+
+        Degree of effectiveness and efficiency with which test criteria can be established
+        for a system, product or component and tests can be performed to determine
+        whether those criteria have been met.'
+    identifier: https://w3id.org/everse/i/dimensions/maintainability
+    name: Maintainability
+    source:
+        name: ISO/IEC 25010 standard
+        url: https://iso25000.com/index.php/en/iso-25000-standards/iso-25010
+-   abbreviation: open_source_software
+    description: Open source software is software with source code that anyone can
+        inspect, modify, and enhance. Research software can be published with or without
+        open access to the source code. Open access to source code aligns better with
+        academic research purposes than closed source software; open source software
+        aligns with the FAIR4RS principles. It allows other researchers to directly
+        verify the methods used to produce the results published in papers. It also
+        makes reproducibility much easier. In addition to these research-driven reasons,
+        publishing research software as open source software can help with long term
+        maintenance in a cost-effective way, since interested developers can easily
+        contribute new functionality or fix bugs. Moreover, by integrating with the
+        greater open source ecosystem, researchers can leverage tools and support
+        communities already available. As such, for most academic communities with
+        limited resources, it is also a good choice from a software engineering perspective
+    identifier: https://w3id.org/everse/i/dimensions/open_source_software
+    name: Open Source Software
+    source:
+    -   identifier: https://doi.org/10.5281/zenodo.14204478
+        name: EVERSE Reference Framework
+        url: https://doi.org/10.5281/zenodo.14204478
+    -   name: What is Open Source?
+        url: https://opensource.com/resources/what-open-source
+-   abbreviation: performance_efficiency
+    description: 'This characteristic represents the degree to which a product performs
+        its functions within specified time and throughput parameters and is efficient
+        in the use of resources (such as CPU, memory, storage, network devices, energy,
+        materials...) under specified conditions. This characteristic is composed
+        of the following sub-characteristics:
+
+
+        **Time behaviour**
+
+
+        Degree to which the response time and throughput rates of a product or system,
+        when performing its functions, meet requirements.
+
+
+        **Resource utilization**
+
+
+        Degree to which the amounts and types of resources used by a product or system,
+        when performing its functions, meet requirements.
+
+
+        **Capacity**
+
+
+        Degree to which the maximum limits of a product or system parameter meet requirements.'
+    identifier: https://w3id.org/everse/i/dimensions/performance_efficiency
+    name: Performance Efficiency
+    source:
+        name: ISO/IEC 25010 standard
+        url: https://iso25000.com/index.php/en/iso-25000-standards/iso-25010
+-   abbreviation: reliability
+    description: 'Degree to which a system, product or component performs specified
+        functions under specified conditions for a specified period of time. This
+        characteristic is composed of the following sub-characteristics:
+
+
+        **Faultlessness**
+
+
+        Degree to which a system, product or component performs specified functions
+        without fault under normal operation.
+
+
+        **Availability**
+
+
+        Degree to which a system, product or component is operational and accessible
+        when required for use.
+
+
+        **Fault tolerance**
+
+
+        Degree to which a system, product or component operates as intended despite
+        the presence of hardware or software faults.
+
+
+        **Recoverability**
+
+
+        Degree to which, in the event of an interruption or a failure, a product or
+        system can recover the data directly affected and re-establish the desired
+        state of the system.'
+    identifier: https://w3id.org/everse/i/dimensions/reliability
+    name: Reliability
+    source:
+        name: ISO/IEC 25010 standard
+        url: https://iso25000.com/index.php/en/iso-25000-standards/iso-25010
+-   abbreviation: safety
+    description: 'This characteristic represents the degree to which a product under
+        defined conditions avoids a state in which human life, health, property, or
+        the environment is endangered. This characteristic is composed of the following
+        sub-characteristics:
+
+
+        **Operational constraint**
+
+
+        Degree to which a product or system constrains its operation to within safe
+        parameters or states when encountering operational hazard.
+
+
+        **Risk identification**
+
+
+        Degree to which a product can identify a course of events or operations that
+        can expose life, property or environment to unacceptable risk.
+
+
+        **Fail safe**
+
+
+        Degree to which a product can automatically place itself in a safe operating
+        mode, or to revert to a safe condition in the event of a failure.
+
+
+        **Hazard warning**
+
+
+        Degree to which a product or system provides warnings of unacceptable risks
+        to operations or internal controls so that they can react in sufficient time
+        to sustain safe operations.
+
+
+        **Safe integration**
+
+
+        Degree to which a product can maintain safety during and after integration
+        with one or more components.'
+    identifier: https://w3id.org/everse/i/dimensions/safety
+    name: Safety
+    source:
+        name: ISO/IEC 25010 standard
+        url: https://iso25000.com/index.php/en/iso-25000-standards/iso-25010
+-   abbreviation: security
+    description: 'Degree to which a product or system defends against attack patterns
+        by malicious actors and protects information and data so that persons or other
+        products or systems have the degree of data access appropriate to their types
+        and levels of authorization. This characteristic is composed of the following
+        sub-characteristics:
+
+
+        **Confidentiality**
+
+
+        Degree to which a product or system ensures that data are accessible only
+        to those authorized to have access.
+
+
+        **Integrity**
+
+
+        Degree to which a system, product or component ensures that the state of its
+        system and data are protected from unauthorized modification or deletion either
+        by malicious action or computer error.
+
+
+        **Non-repudiation**
+
+
+        Degree to which actions or events can be proven to have taken place so that
+        the events or actions cannot be repudiated later.
+
+
+        **Accountability**
+
+
+        Degree to which the actions of an entity can be traced uniquely to the entity.
+
+
+        **Authenticity**
+
+
+        Degree to which the identity of a subject or resource can be proved to be
+        the one claimed.
+
+
+        **Resistance**
+
+
+        Degree to which the product or system sustains operations while under attack
+        from a malicious actor.'
+    identifier: https://w3id.org/everse/i/dimensions/security
+    name: Security
+    source:
+        name: ISO/IEC 25010 standard
+        url: https://iso25000.com/index.php/en/iso-25000-standards/iso-25010
+-   abbreviation: sustainability
+    description: The capacity of the software to endure. In other words, sustainability
+        means that the software will continue to be available in the future, on new
+        platforms, meeting new needs.
+    identifier: https://w3id.org/everse/i/dimensions/sustainability
+    name: Sustainability
+    source:
+        name: Defining Software Sustainability
+        url: https://danielskatzblog.wordpress.com/2016/09/13/defining-software-sustainability/

--- a/_data/quality_indicators.yml
+++ b/_data/quality_indicators.yml
@@ -226,8 +226,7 @@
         url: https://fair-impact.github.io/RSMD-guidelines/4.Description_Classification/
     status: Active
     version: 1.0.0
-- &id001
-    abbreviation: functional_correctness
+-   abbreviation: functional_correctness
     author:
         '@type': schema:Organization
         name: University of Padova
@@ -259,29 +258,876 @@
         url: https://dome-ml.org/guidelines#evaluation-section
     status: Active
     version: 1.0.0
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
-- *id001
+-   abbreviation: has_ci-tests
+    author:
+        '@type': schema:Organization
+        name: OpenSSF
+        url: https://openssf.org/
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-05-2025
+    description: This indicator aims to determine if the project runs tests before
+        pull requests are merged.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/has_ci-tests
+    keywords:
+    - continuous
+    - integration
+    - test
+    name: Software has continuous integration tests
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/maintainability
+    relevant in tiers:
+        Relevant for Analysis Code: good to have
+        Relevant for Prototype tool: good to have
+        Relevant for RS infrastructure: crucial
+    source:
+        name: 'OpenSSF Scorecard: CI-Tests'
+        url: https://github.com/ossf/scorecard/blob/cd152cb6742c5b8f2f3d2b5193b41d9c50905198/docs/checks.md#ci-tests
+    status: Active
+    version: 1.0.0
+-   abbreviation: has_contribution_guidelines
+    author:
+        '@type': schema:Organization
+        name: CESSDA
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 17-03-2026
+    description: The software repository provides contribution guidelines in case
+        someone wants to contribute to the project.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/has_contribution_guidelines
+    keywords:
+    - linting
+    - code analysis
+    - fair
+    name: Software repository has contribution guidelines
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/sustainability
+    source:
+    -   name: Software Requirements
+        url: https://docs.tech.cessda.eu/software/requirements.html
+    status: Active
+    version: 1.0.0
+-   abbreviation: has_no_linting_issues
+    alternateName: has_no_linting_issues
+    author:
+        '@type': schema:Organization
+        name: Super-Linter
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-06-2025
+    description: The project addresses or resolves warnings identified by compilers,
+        safe modes, or linters.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/has_no_linting_issues
+    keywords:
+    - linting
+    - code analysis
+    - fair
+    name: Software has no linting issues
+    qualityDimension:
+    -   '@id': https://w3id.org/everse/i/dimensions/fairness
+    -   '@id': https://w3id.org/everse/i/dimensions/maintainability
+    relevant in tiers:
+        Relevant for Analysis Code: good to have
+        Relevant for Prototype tool: good to have
+        Relevant for RS infrastructure: crucial
+    source:
+    -   name: Super-Linter
+        url: https://github.com/super-linter/super-linter
+    -   name: OpenSSF best practices
+        url: https://www.bestpractices.dev/en/criteria/0#0.warnings_fixed
+    status: Active
+    version: 1.0.0
+-   abbreviation: has_published_package
+    author:
+        '@type': schema:Organization
+        name: OpenSSF
+        url: https://openssf.org/
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-05-2025
+    description: This indicator aims to determine if a software project is published
+        as a downloadable package.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/has_published_package
+    keywords:
+    - release
+    - fair
+    - package
+    - packaging
+    name: Software is published as a downloadable package
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/flexibility
+    relevant in tiers:
+        Relevant for Analysis Code: not relevant
+        Relevant for Prototype tool: not relevant
+        Relevant for RS infrastructure: recommended
+    source:
+        name: 'OpenSSF Scorecard: Packaging'
+        url: https://github.com/ossf/scorecard/blob/cd152cb6742c5b8f2f3d2b5193b41d9c50905198/docs/checks.md#packaging
+    status: Active
+    version: 1.0.0
+-   abbreviation: has_releases
+    alternateName: FRSM-03
+    author:
+        '@type': schema:Organization
+        name: OpenSSF
+        url: https://openssf.org/
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-05-2025
+    description: To enable collaborative review, the project's source repository MUST
+        include interim versions for review between releases; it MUST NOT include
+        only final releases. This indicator determines if a software project has releases.
+        This can be achieved by looking for tags or using software that retrieves
+        related data.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/has_releases
+    keywords:
+    - releases
+    - repository
+    - fair
+    name: Software has releases
+    qualityDimension:
+    -   '@id': https://w3id.org/everse/i/dimensions/maintainability
+    -   '@id': https://w3id.org/everse/i/dimensions/fairness
+    relevant in tiers:
+        Relevant for Analysis Code: good to have
+        Relevant for Prototype tool: good to have
+        Relevant for RS infrastructure: crucial
+    sameAs: https://doi.org/10.25504/FAIRsharing.ef9fc3
+    source:
+        name: OpenSSF Best Practices (change control)
+        url: https://www.bestpractices.dev/en/criteria/0#0.repo_interim
+    status: Active
+    version: 1.0.0
+-   abbreviation: human_code_review_requirement
+    author:
+        '@type': schema:Organization
+        name: OpenSSF
+        url: https://openssf.org/
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-05-2025
+    description: This indicator aims to determine if a software project requires human
+        code review before pull requests.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/human_code_review_requirement
+    keywords:
+    - human-in-the-loop
+    - pull request
+    - review
+    name: Software requires human code review.
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/functional_suitability
+    relevant in tiers:
+        Relevant for Analysis Code: not relevant
+        Relevant for Prototype tool: not relevant
+        Relevant for RS infrastructure: good to have
+    source:
+        name: 'OpenSSF Scorecard: Code-Review'
+        url: https://github.com/ossf/scorecard/blob/cd152cb6742c5b8f2f3d2b5193b41d9c50905198/docs/checks.md#code-review
+    status: Active
+    version: 1.0.0
+-   abbreviation: internal_cohesion_ok
+    author:
+        '@type': schema:Person
+        name: Daniel Garijo
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 11-03-2026
+    description: The cohesion among methods/functions of a module is maintained to
+        a reasonable level according to community expectations and standards. Cohesion
+        describes how related the functions within a single module are. Low cohesion
+        implies that a given module performs tasks which are not very related to each
+        other and hence can create problems as the module becomes large
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/internal_cohesion_ok
+    keywords:
+    - maintainability
+    - cohesion
+    - module
+    - code
+    name: Cohesion among methods/functions of a module follows community conventions
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/maintainability
+    source:
+    -   identifier: https://zenodo.org/records/10647227
+        name: Task Force Sub Group 3 - Review of Software Quality Attributes and Characteristics
+        url: https://zenodo.org/records/10647227
+    -   name: 'Socially-Informed Jupyter Notebook Quality: A Role- and Lifecycle-Aware
+            Metrics Framework'
+        url: https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=11216562&tag=1
+    status: Active
+    version: 1.0.0
+-   abbreviation: lines_of_code_ok
+    author:
+        '@type': schema:Person
+        name: Daniel Garijo
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 10-03-2026
+    description: Number of lines of code for the whole software project or components/modules/classes/functions/methods
+        should follow the conventions established by the community responsible for
+        maintaining the source code
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/lines_of_code_ok
+    keywords:
+    - maintainability
+    - lines, code
+    name: Number of lines of code follows community standards or expectations
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/maintainability
+    source:
+    -   identifier: https://zenodo.org/records/10647227
+        name: Task Force Sub Group 3 - Review of Software Quality Attributes and Characteristics
+        url: https://zenodo.org/records/10647227
+    -   name: 'Socially-Informed Jupyter Notebook Quality: A Role- and Lifecycle-Aware
+            Metrics Framework'
+        url: https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=11216562&tag=1
+    status: Active
+    version: 1.0.0
+-   abbreviation: listed_in_registry
+    author:
+        '@type': schema:Organization
+        name: FAIR-IMPACT
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-06-2025
+    description: The target source code repository is in a disciplinary or community
+        registry (e.g ascl.net, bio.tools, swMath, RRID portal, RSD, WikiData, DataCite,
+        etc.) to ensure that software can be found and accessed.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/listed_in_registry
+    keywords:
+    - repository
+    - fair
+    - software heritage, zenodo
+    name: Software is listed in a registry
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/fairness
+    relevant in tiers:
+        Relevant for Analysis Code: recommended
+        Relevant for Prototype tool: recommended
+        Relevant for RS infrastructure: crucial
+    source:
+        '@id': https://fair-impact.github.io/RSMD-guidelines/8.rsmd_checklist/
+        name: Accessibility and preservation. RSMD 2.3
+        url: https://fair-impact.github.io/RSMD-guidelines/8.rsmd_checklist/#accessibility-and-preservation
+    status: Active
+    version: 1.0.0
+-   abbreviation: metadata_is_up_to_date
+    author:
+    -   '@type': schema:Person
+        name: Tom François
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Thomas Vuillaume
+    contact:
+    -   '@type': schema:Person
+        name: Tom François
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    created: 24-09-2025
+    description: Metadata information reflects the current description of a software
+        project. This indicator ensures that the current project metadata provides
+        up to date, accurate and relevant information about a software component.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/metadata_is_up_to_date
+    keywords:
+    - metadata
+    - software
+    - fair
+    - findability
+    - maintainability
+    name: Software has up-to-date metadata
+    qualityDimension:
+    -   '@id': https://w3id.org/everse/i/dimensions/fairness
+    -   '@id': https://w3id.org/everse/i/dimensions/maintainability
+    relevant in tiers:
+        Relevant for Analysis Code: good to have
+        Relevant for Prototype tool: good to have
+        Relevant for RS infrastructure: recommended
+    source:
+    -   name: 'EOSC-SWRelMan-11: Metadata: Supportability, Maintainability, Availability.'
+        url: https://doi.org/10.5281/zenodo.10647227
+    status: Active
+    version: 1.0.0
+-   abbreviation: no_critical_vulnerability
+    author:
+    -   '@type': schema:Organization
+        name: OpenSSF
+        url: https://openssf.org/
+    contact:
+        '@type': schema:Person
+        name: Tom François
+        schema:email: tom.francois@lapp.in2p3.fr
+    created: 03-04-2025
+    description: Checks if reported critical vulnerabilities have been fixed
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/no_critical_vulnerability
+    keywords:
+    - security
+    - critical
+    - vulnerability
+    name: No critical vulnerabilities
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/security
+    relevant in tiers:
+        Relevant for Analysis Code: good to have
+        Relevant for Prototype tool: good to have
+        Relevant for RS infrastructure: crucial
+    source:
+    -   '@id': https://www.bestpractices.dev/en/criteria/0#0.vulnerabilities_critical_fixed
+        name: OpenSSF Best practice Critical Vulnerability Fixed
+    status: Active
+    version: 1.0.0
+-   abbreviation: no_leaked_credentials
+    author:
+    -   '@type': schema:Organization
+        name: OpenSSF
+        url: https://openssf.org/
+    contact:
+        '@type': schema:Person
+        name: Tom François
+        schema:email: tom.francois@lapp.in2p3.fr
+    description: Checks if hardcoded secrets like passwords, API keys, and tokens
+        is stored in the public git repository
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/no_leaked_credentials
+    keywords:
+    - security
+    - credential
+    - leak
+    - secret
+    - password
+    name: No leaked credentials
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/security
+    relevant in tiers:
+        Relevant for Analysis Code: crucial
+        Relevant for Prototype tool: crucial
+        Relevant for RS infrastructure: crucial
+    source:
+    -   '@id': https://www.bestpractices.dev/en/criteria/0#0.no_leaked_credentials
+        name: OpenSSF Best practice No Leaked Credentials
+    status: Active
+    version: 1.0.0
+-   abbreviation: persistent_and_unique_identifier
+    alternateName: FRSM-01
+    author:
+        '@type': schema:Organization
+        name: FAIR-IMPACT
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-05-2025
+    description: This indicator tries to determine if the software identifier is based
+        on a suitable identifier scheme, and test it can be resolved. This is done
+        by checking if the identifier uses an identifier scheme contained in a list
+        of globally unique identifier schemes
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/persistent_and_unique_identifier
+    keywords:
+    - identifier
+    - unique
+    - fair
+    - persistent
+    - metadata
+    name: Software has persistent and unique identifier
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/fairness
+    relevant in tiers:
+        Relevant for Analysis Code: recommended
+        Relevant for Prototype tool: recommended
+        Relevant for RS infrastructure: crucial
+    sameAs: https://doi.org/10.25504/FAIRsharing.87c9a8
+    source:
+        name: D5.2 - Metrics for automated FAIR software assessment in a disciplinary
+            context
+        url: https://zenodo.org/records/10047401
+    status: Active
+    version: 1.0.0
+-   abbreviation: repository_workflows
+    author:
+        '@type': schema:Organization
+        name: OpenSSF
+        url: https://openssf.org/
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-05-2025
+    description: This indicator tries aims determine if a software project makes use
+        of workflows to automate processes like testing and deployment.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/repository_workflows
+    keywords:
+    - workflows
+    - github
+    - fair
+    - repository
+    name: Software has ci/cd workflows in its repository
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/maintainability
+    relevant in tiers:
+        Relevant for Analysis Code: good to have
+        Relevant for Prototype tool: good to have
+        Relevant for RS infrastructure: crucial
+    source:
+    -   name: 'OpenSSF Scorecard: CI-Tests'
+        url: https://github.com/ossf/scorecard/blob/cd152cb6742c5b8f2f3d2b5193b41d9c50905198/docs/checks.md#ci-tests
+    status: Active
+    version: 1.0.0
+-   abbreviation: requirements_specified
+    alternateName: FRSM-13
+    author:
+        '@type': schema:Organization
+        name: FAIR-IMPACT
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-05-2025
+    description: This indicator tries to determine if the project specifies what is
+        required to use the software.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/requirements_specified
+    keywords:
+    - documentation
+    - requirements
+    - dependencies
+    - fair
+    name: Software specifies requirements
+    qualityDimension:
+    -   '@id': https://w3id.org/everse/i/dimensions/fairness
+    -   '@id': https://w3id.org/everse/i/dimensions/flexibility
+    -   '@id': https://w3id.org/everse/i/dimensions/maintainability
+    relevant in tiers:
+        Relevant for Analysis Code: good to have
+        Relevant for Prototype tool: recommended
+        Relevant for RS infrastructure: crucial
+    sameAs: https://doi.org/10.25504/FAIRsharing.b8eeb9
+    source:
+    -   name: D5.2 - Metrics for automated FAIR software assessment in a disciplinary
+            context
+        url: https://zenodo.org/records/10047401
+    -   name: 'RSMD Guidelines - Re-execute: dependencies and execution environment'
+        url: https://fair-impact.github.io/RSMD-guidelines/7.Re-execute/
+    status: Active
+    version: 1.0.0
+-   abbreviation: software_has_citation
+    alternateName: FRSM-12
+    author:
+        '@type': schema:Organization
+        name: FAIR-IMPACT
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-05-2025
+    description: This indicator aims to determine if the project uses a citation to
+        reference contributors and authors (e.g., through a CFF file, in the README,
+        etc).
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/software_has_citation
+    keywords:
+    - citation
+    - metadata
+    - fair
+    - contributors
+    name: Software uses citation
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/fairness
+    relevant in tiers:
+        Relevant for Analysis Code: good to have
+        Relevant for Prototype tool: good to have
+        Relevant for RS infrastructure: crucial
+    sameAs: https://doi.org/10.25504/FAIRsharing.c585c5
+    source:
+    -   name: Research Software Metadata guidelines - Credit and attribution
+        url: https://fair-impact.github.io/RSMD-guidelines/5.Credit_Attribution/
+    -   name: D5.2 - Metrics for automated FAIR software assessment in a disciplinary
+            context
+        url: https://zenodo.org/records/10047401
+    status: Active
+    version: 1.0.0
+-   abbreviation: software_has_documentation
+    alternateName: FRSM-05
+    author:
+        '@type': schema:Organization
+        name: OpenSSF
+        url: https://openssf.org/
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-05-2025
+    description: This indicator aims to determine if a software project comes with
+        many forms of documentation like readme or readthedocs
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/software_has_documentation
+    keywords:
+    - documentation
+    - fair
+    - usage
+    - readme
+    name: Software has documentation
+    qualityDimension:
+    -   '@id': https://w3id.org/everse/i/dimensions/fairness
+    -   '@id': https://w3id.org/everse/i/dimensions/interaction_capability
+    relevant in tiers:
+        Relevant for Analysis Code: good to have
+        Relevant for Prototype tool: recommended
+        Relevant for RS infrastructure: crucial
+    sameAs: https://doi.org/10.25504/FAIRsharing.452bcd
+    source:
+        name: FLOSS Best Practices Criteria
+        url: https://www.bestpractices.dev/en/criteria/0#0.documentation_basics
+    status: Active
+    version: 1.0.0
+-   abbreviation: software_has_license
+    alternateName: FRSM-15
+    author:
+        '@type': schema:Organization
+        name: OpenSSF
+        url: https://openssf.org/
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-05-2025
+    description: This check tries to determine if the project has published a license
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/software_has_license
+    keywords:
+    - license
+    - metadata
+    - fair
+    name: Software has license
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/fairness
+    relevant in tiers:
+        Relevant for Analysis Code: crucial
+        Relevant for Prototype tool: crucial
+        Relevant for RS infrastructure: crucial
+    source:
+    -   name: 'OpenSSF Scorecard: License'
+        url: https://github.com/ossf/scorecard/blob/cd152cb6742c5b8f2f3d2b5193b41d9c50905198/docs/checks.md#license
+    -   name: Reuse, licensing and legal aspects. RSMD-6.2
+        url: https://fair-impact.github.io/RSMD-guidelines/6.Reuse_legal/
+    status: Active
+    version: 1.0.0
+-   abbreviation: software_has_tests
+    alternateName: FRSM-14
+    author:
+        '@type': schema:Organization
+        name: FAIR-IMPACT
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-05-2025
+    description: Evaluates the extent to which the software has been tested, including
+        unit tests, integration tests, and system tests, to ensure reliability and
+        correctness.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/software_has_tests
+    keywords:
+    - test
+    - functionality
+    - fair
+    name: Software provides tests.
+    qualityDimension:
+    -   '@id': https://w3id.org/everse/i/dimensions/fairness
+    -   '@id': https://w3id.org/everse/i/dimensions/reliability
+    relevant in tiers:
+        Relevant for Analysis Code: not relevant
+        Relevant for Prototype tool: good to have
+        Relevant for RS infrastructure: crucial
+    sameAs: https://doi.org/10.25504/FAIRsharing.a2dd1a
+    source:
+        name: D5.2 - Metrics for automated FAIR software assessment in a disciplinary
+            context
+        url: https://zenodo.org/records/10047401
+    status: Active
+    version: 1.0.0
+-   abbreviation: software_test_coverage
+    author:
+        '@type': schema:Organization
+        name: ELIXIR-Steers
+        url: https://elixir-europe.org/about-us/how-funded/eu-projects/steers
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 03-12-2025
+    description: Indicates that the test suite covers most (or ideally all) the code
+        branches, input fields, and functionality
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/software_test_coverage
+    keywords:
+    - test coverage
+    - code coverage
+    - branch coverage
+    - coverage threshold
+    - test completeness
+    name: Software has sufficient test coverage
+    qualityDimension:
+    -   '@id': https://w3id.org/everse/i/dimensions/reliability
+    -   '@id': https://w3id.org/everse/i/dimensions/functional_suitability
+    source:
+        name: ELIXIR Steers D2.1 Report on best-practices and indicators available
+            and used by selected Communities
+        url: https://doi.org/10.5281/zenodo.17035105
+    status: Active
+    version: 0.0.1
+-   abbreviation: static_analysis_common_vulnerabilities
+    author:
+        '@type': Organization
+        name: OpenSSF
+        url: https://openssf.org/
+    contactPoint:
+        '@type': schema:Person
+        email: thomas.vuillaume@lapp.in2p3.fr
+        name: Thomas Vuillaume
+    created: 03-04-2025
+    description: At least one static code analysis tool used includes rules or techniques
+        to detect common vulnerabilities specific to the language or environment.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/static_analysis_common_vulnerabilities
+    keywords:
+    - security
+    - vulnerabilities
+    - static analysis
+    name: Has static analysis for common vulnerabilities
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/security
+    relevant in tiers:
+        Relevant for Analysis Code: good to have
+        Relevant for Prototype tool: good to have
+        Relevant for RS infrastructure: crucial
+    source:
+        '@id': https://www.bestpractices.dev/en/criteria/0
+        name: FLOSS Best Practices Criteria (Passing Badge)
+        url: https://www.bestpractices.dev/en/criteria/0#0.static_analysis_common_vulnerabilities
+    status: Active
+    version: 1.0.0
+-   abbreviation: support_issue_tracking
+    author:
+        '@type': Organization
+        name: OpenSSF
+        url: https://openssf.org/
+    contactPoint:
+        '@type': schema:Person
+        email: federica.quaglia@unipd.it
+        name: Federica Quaglia
+    created: 03-12-2025
+    description: The software project offers an accessible issue tracking system (e.g.,
+        GitHub/GitLab Issues or a helpdesk) that is used to report, document, and
+        manage bugs, enhancement requests, and user-facing operational issues.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/support_issue_tracking
+    keywords:
+    - support
+    - issues
+    - helpdesk
+    - maintenance
+    - user support
+    name: Software provides issue tracking
+    qualityDimension:
+        '@id': 'https://w3id.org/everse/i/dimensions/maintainability '
+    source:
+        '@id': https://zenodo.org/records/17035105
+        name: ELIXIR-STEERS D2.1 Report on best-practices and indicators available
+            and used by selected Communities
+        url: https://zenodo.org/records/17035105
+    status: Active
+    version: 1.0.0
+-   abbreviation: uses_fuzzing
+    author:
+        '@type': schema:Organization
+        name: OpenSSF
+        url: https://openssf.org/
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-06-2025
+    description: 'This indicator checks that the software produced by the project
+        includes software written using a memory-unsafe language (e.g., C or C++),
+        then at least one dynamic tool (e.g., a fuzzer or web application scanner)
+        be routinely used in combination with a mechanism to detect memory safety
+        problems such as buffer overwrites. '
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/uses_fuzzing
+    keywords:
+    - fuzzing
+    - test
+    - code
+    name: Software uses fuzzing
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/safety
+    relevant in tiers:
+        Relevant for Analysis Code: not relevant
+        Relevant for Prototype tool: not relevant
+        Relevant for RS infrastructure: good to have
+    source:
+        name: 'OpenSSF Scorecard: Fuzzing'
+        url: https://github.com/ossf/scorecard/blob/cd152cb6742c5b8f2f3d2b5193b41d9c50905198/docs/checks.md#fuzzing
+    status: Active
+    version: 1.0.0
+-   abbreviation: uses_tool_for_warnings_and_mistakes
+    author:
+        '@type': schema:Organization
+        name: OpenSSF
+        url: https://openssf.org/
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 27-06-2025
+    description: This indicator checks that the project enables one or more compiler
+        warning flags, a "safe" language mode, or uses a separate "linter" tool to
+        look for code quality errors or common simple mistakes, if there is at least
+        one FLOSS tool that can implement this criterion in the selected language.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/uses_tool_for_warnings_and_mistakes
+    keywords:
+    - linting
+    - code analysis
+    - fair
+    name: Software uses a tool for warnings or mistakes
+    qualityDimension:
+    -   '@id': https://w3id.org/everse/i/dimensions/fairness
+    -   '@id': https://w3id.org/everse/i/dimensions/maintainability
+    relevant in tiers:
+        Relevant for Analysis Code: good to have
+        Relevant for Prototype tool: good to have
+        Relevant for RS infrastructure: recommended
+    source:
+    -   name: 'OpenSSF Best Practices badge: Warning Flags'
+        url: https://www.bestpractices.dev/en/criteria/0#0.warnings
+    -   '@id': https://zenodo.org/records/10723608
+        name: Ensure Software Quality
+        url: https://zenodo.org/records/10723608
+    status: Active
+    version: 1.0.0
+-   abbreviation: version_control_use
+    alternateName: FRSM-17
+    author:
+    -   '@type': schema:Organization
+        name: Elixir focus group
+        url: https://zenodo.org/communities/elixir/records
+    -   '@type': schema:Organization
+        name: FAIR-IMPACT
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 23-05-2025
+    description: This indicator aims to determine if a software project uses version
+        control.
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/version_control_use
+    keywords:
+    - version
+    - control
+    - fair
+    - repository
+    - identifier
+    name: Software makes use of version control
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/fairness
+    relevant in tiers:
+        Relevant for Analysis Code: crucial
+        Relevant for Prototype tool: crucial
+        Relevant for RS infrastructure: crucial
+    sameAs: https://doi.org/10.25504/FAIRsharing.d2b2c5
+    source:
+    -   name: D5.2 - Metrics for automated FAIR software assessment in a disciplinary
+            context
+        url: https://zenodo.org/records/10047401
+    -   name: 'Software Quality Indicators: extraction, categorisation and recommendations
+            from canonical sources'
+        url: https://doi.org/10.5281/zenodo.15474784
+    -   name: Reference and identification. RSMD-3.1
+        url: https://fair-impact.github.io/RSMD-guidelines/3.Reference_identification/
+    status: Active
+    version: 1.0.0
+-   abbreviation: versioning_standards_use
+    author:
+        '@type': schema:Organization
+        name: FAIR-IMPACT
+    contact:
+    -   '@type': schema:Person
+        name: Daniel Garijo
+    -   '@type': schema:Person
+        name: Andres Montero
+    created: 14-07-2025
+    description: This indicator aims to determine if the version (or versions) of
+        a software tool follows an established community convention like semantic
+        versioning (SemVer) or calendar versioning (CalVer).
+    identifier:
+        '@id': https://w3id.org/everse/i/indicators/versioning_standards_use
+    keywords:
+    - version
+    - versioning
+    - fair
+    - releases
+    name: Software follows versioning standards
+    qualityDimension:
+        '@id': https://w3id.org/everse/i/dimensions/fairness
+    relevant in tiers:
+        Relevant for Analysis Code: good to have
+        Relevant for Prototype tool: recommended
+        Relevant for RS infrastructure: crucial
+    source:
+        '@id': https://doi.org/10.5281/zenodo.15535629
+        name: D5.2 - Metrics for automated FAIR software assessment in a disciplinary
+            context
+        url: https://doi.org/10.5281/zenodo.15535629
+    status: Active
+    version: 1.0.0

--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -1237,3 +1237,8 @@
     CODECHECK tackles one of the main challenges of computational research by supporting codecheckers with a workflow, guidelines and tools to evaluate computer programs underlying scientific papers.
   url: https://codecheck.org.uk/
   catalog: RSQKit
+- id: rsfc
+  name: RSFC
+  description: >-
+    A command line tool that performs a quality assessment based on a series of Research Software Quality Indicators (RSQIs)
+  url: https://rsfc.linkeddata.es

--- a/pages/tasks/fair_rs.md
+++ b/pages/tasks/fair_rs.md
@@ -77,9 +77,10 @@ Tools and frameworks exist for assessing software FAIRness:
 
 - {% tool "fair-rs-checklist" %} - a self-assessment tool developed by the Australian Research Data Commons (ARDC) and the Netherlands eScience Center
 - {% tool "fair-rs-evaluator" %} - OpenBench's tool for assessing the FAIRness of software tool from its metadata
-- {% tool "fair-rs-checklist" %} - a self-assessment tool developed by the Australian Research Data Commons (ARDC) and the Netherlands eScience Center- {% tool "howfairis" %} - a command line tool to evaluate a software repository's compliance with the FAIR principles
+- {% tool "howfairis" %} - a command line tool to evaluate a software repository's compliance with the FAIR principles
 - {% tool "codecheck" %} - an approach for independent execution of computations underlying research articles
 - [Common metrics for Research Software][fair-metrics] that may used to assess each of the FAIR4RS principles
+- {% tool "rsfc" %} - a command line interface to automatically evaluate the FAIRness of a Github or Gitlab repository
 
 They not meant to criticise or discredit software or its authors. 
 Their role is to make quality aspects visible, help researchers identify strengths and areas for improvement, and support the evolution of good practices. 
@@ -123,3 +124,4 @@ This is a suggested list tool-specific sub-tasks to have a look at.
 [testing_software]: ./testing_software
 [citing_software]: ./citing_software
 [organising_software_projects]: ./organising_software_projects
+[rsfc]: https://rsfc.linkeddata.es


### PR DESCRIPTION
Changes proposed in this pull request:

- Added RSFC to the "Tools and practices for FAIR" section in the fair_rs.md page
- Fixed format in the same page and a duplication issue with one of its entries
- Also modified tool_and_resource_list.yml to add RSFC so it is recognized as a tool in the fair_rs.md page

Notes for reviewers: 

Talked these changes with @dgarijo 
Tested locally and it works
