### PR TITLE
Annotation of missing quality indicators for task pages

### DIFF
--- a/pages/tasks/archiving_software.md
+++ b/pages/tasks/archiving_software.md
@@ -3,7 +3,7 @@ title: Archiving software
 description: How can you archive your software for preservation?
 contributors: ["Aleksandra Nenadic"]
 page_id: archiving_software
-indicators: []
+indicators: [archived_in_software_heritage, archived_in_scholarly_repository, listed_in_registry]
 related_pages:
   tasks: [software_identifiers, software_metadata, documenting_software, licensing_software]
 keywords: ["archiving software", "software preservation"]

--- a/pages/tasks/code_review.md
+++ b/pages/tasks/code_review.md
@@ -5,7 +5,7 @@ contributors: ["Aleksandra Nenadic"]
 page_id: code_review
 related_pages:
   tasks: []
-quality_indicators: [human_code_review_requirement, uses_tool_for_warnings_and_mistakes, lines_of_code_ok, internal_cohesion_ok, coupling_between_objects_ok, has_no_linting_issues, cyclomatic_complexity_ok]
+quality_indicators: [human_code_review_requirement, uses_tool_for_warnings_and_mistakes, has_no_linting_issues]
 keywords: ["code review"]
 ---
 

--- a/pages/tasks/code_review.md
+++ b/pages/tasks/code_review.md
@@ -5,7 +5,7 @@ contributors: ["Aleksandra Nenadic"]
 page_id: code_review
 related_pages:
   tasks: []
-quality_indicators: [human_code_review_requirement, uses_tool_for_warnings_and_mistakes]
+quality_indicators: [human_code_review_requirement, uses_tool_for_warnings_and_mistakes, lines_of_code_ok, internal_cohesion_ok, coupling_between_objects_ok, has_no_linting_issues, cyclomatic_complexity_ok]
 keywords: ["code review"]
 ---
 

--- a/pages/tasks/code_review.md
+++ b/pages/tasks/code_review.md
@@ -5,7 +5,7 @@ contributors: ["Aleksandra Nenadic"]
 page_id: code_review
 related_pages:
   tasks: []
-quality_indicators: [human_code_review_requirement]
+quality_indicators: [human_code_review_requirement, uses_tool_for_warnings_and_mistakes]
 keywords: ["code review"]
 ---
 

--- a/pages/tasks/organising_software_projects.md
+++ b/pages/tasks/organising_software_projects.md
@@ -5,7 +5,7 @@ contributors: ["Aleksandra Nenadic"]
 page_id: organising_software_projects
 related_pages:
   tasks: [citing_software, creating_good_readme, documenting_software, software_metadata]
-quality_indicators: []
+quality_indicators: [software_has_documentation, internal_cohesion]
 keywords: ["software project", "organising software project"]
 ---
 

--- a/pages/tasks/organising_software_projects.md
+++ b/pages/tasks/organising_software_projects.md
@@ -5,7 +5,7 @@ contributors: ["Aleksandra Nenadic"]
 page_id: organising_software_projects
 related_pages:
   tasks: [citing_software, creating_good_readme, documenting_software, software_metadata]
-quality_indicators: [software_has_documentation, internal_cohesion]
+quality_indicators: [software_has_documentation]
 keywords: ["software project", "organising software project"]
 ---
 

--- a/pages/tasks/publishing_software.md
+++ b/pages/tasks/publishing_software.md
@@ -2,7 +2,7 @@
 title: Publishing software
 description: How do you publish your software for reuse by others?
 page_id: publishing_software
-indicators: []
+indicators: [has_releases, software_has_documentation, has_published_package, software_has_license, has_contribution_guidelines, versioning_standards_use, archived_in_software_heritage, archived_in_scholarly_repository, listed_in_registry, descriptive_metadata, software_has_citation]
 child_pages: [software_documentation, software_metadata, software_identifiers, citing_software, packaging_software, releasing_software, archiving_software] 
 #keywords: ["software publishing", "software documentation", "software license", "software licence", "publish software", "software packaging", "software citation", "software identifiers", "software archiving"]
 page_citation: false

--- a/pages/tasks/releasing_software.md
+++ b/pages/tasks/releasing_software.md
@@ -5,7 +5,7 @@ contributors: ["Christian Hüser", "Shoaib Sufi", "Daniel Garijo"]
 page_id: releasing_software
 related_pages:
   tasks: [software_identifiers, packaging_software, publishing_software]
-quality_indicators: [has_releases]
+quality_indicators: [has_releases, versioning_standards_use]
 keywords: ["release software", "releasing software", "releasing code", "release code"]
 
 ---

--- a/pages/tasks/testing_software.md
+++ b/pages/tasks/testing_software.md
@@ -5,7 +5,7 @@ contributors: ["Aleksandra Nenadic", "Christian Hüser", "Patrick Bos"]
 page_id: testing_software
 related_pages:
   tasks: []
-quality_indicators: [software_has_tests, has_ci-tests]
+quality_indicators: [software_has_tests, has_ci-tests, software_test_coverage]
 keywords: ["software testing", "code testing", "software test", "code test"]
 
 ---


### PR DESCRIPTION
Before creating a pull request:

Fixes #562 

Changes proposed in this pull request:

Added annotations for missing indicators for the following pages

- pages/tasks/archiving_software.md
- pages/tasks/code_review.md
- pages/tasks/organising_software_projects.md
- pages/tasks/publishing_software.md
- pages/tasks/releasing_software.md
- pages/tasks/testing_software.md

Notes for reviewers: 

Review pending by @dgarijo 
