### PR TITLE
Provide links for TechRadar tools onto All resources page

### DIFF
--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -182,7 +182,7 @@
     research papers, data sets, research software, reports, and other
     research-related digital artefacts.
   url: 'https://zenodo.org/'
-  catalog: RSQKit
+  catalog: TechRadar
 - id: figshare
   name: FigShare
   description: >-
@@ -258,12 +258,12 @@
   description: Publish static websites directly from GitHub repository
   url: 'https://pages.github.com/'
   catalog: TechRadar
-- id: github-actions
+- id: github_actions
   name: GitHub Actions
   description: 'GitHub''s infrastructure for continuous integration, deployment and delivery'
   url: 'https://github.com/features/actions'
   catalog: TechRadar
-- id: gitlab-ci-cd
+- id: gitlab-cicd
   name: GitLab CI/CD
   description: 'GitLab''s infrastructure for continuous integration, deployment and delivery'
   url: 'https://docs.gitlab.com/ee/topics/build_your_application.html'
@@ -304,7 +304,7 @@
     prioritize security and privacy risks.
   url: 'https://github.com/bearer/bearer'
   catalog: TechRadar
-- id: hermesworkflows
+- id: hermes-workflow
   name: Hermes Workflows
   description: >-
     The HERMES workflow enables automated publication of rich research software
@@ -312,7 +312,7 @@
     tooling.
   url: 'https://docs.software-metadata.pub/en/latest/'
   catalog: TechRadar
-- id: cffinitgenerator
+- id: cffinit
   name: CFFINIT Generator
   description: >-
     Generate software citation metadata files with ease. CITATION.cff files are
@@ -320,7 +320,7 @@
     software (and datasets).
   url: 'https://citation-file-format.github.io/cff-initializer-javascript/#/'
   catalog: TechRadar
-- id: codemetagenerator
+- id: codemeta-generator
   name: CodeMeta Generator
   description: >-
     A free, open-source project that creates a minimal metadata schema for
@@ -356,7 +356,7 @@
   description: Automated Python code formatter
   url: 'https://github.com/psf/black'
   catalog: TechRadar
-- id: precommit
+- id: pre-commit
   name: precommit
   description: A framework for managing and maintaining multi-language pre-commit hooks
   url: 'https://pre-commit.com/'
@@ -368,12 +368,12 @@
     SPDX Tags
   url: 'https://reuse.software/'
   catalog: TechRadar
-- id: fairaware
+- id: fair-aware
   name: FAIR Aware
   description: Guided approach to assess the FAIRness of data
   url: 'https://fairaware.dans.knaw.nl/'
   catalog: TechRadar
-- id: creativecommons-licence-chooser
+- id: creative-commons-license-chooser
   name: Creative Commons License Chooser
   description: >-
     Creative Commons license chooser to help you select an appropriate Creative
@@ -424,8 +424,8 @@
     environments.
   url: 'https://apptainer.org/'
   catalog: TechRadar
-- id: singularity
-  name: Singularity
+- id: singularityce 
+  name: SingularityCE
   description: >-
     Singularity is an open source container platform allows us to create and run
     containers that package up pieces of software in a way that is portable and
@@ -528,8 +528,8 @@
   description: 'Automation server to support building, testing and deploying software'
   url: 'https://www.jenkins.io/'
   catalog: TechRadar
-- id: travis
-  name: Travis
+- id: travis-ci
+  name: Travis CI
   description: 'CI platform to support building, testing and deploying software'
   url: 'https://www.travis-ci.com/'
   catalog: TechRadar
@@ -580,7 +580,7 @@
     Invenio Framework and Zenodo
   url: 'https://inveniosoftware.org/products/rdm/'
   catalog: RSQKit
-- id: softwareheritage
+- id: software-heritage
   name: Software Heritage
   description: >-
     Software Heritage archive is the largest public collection of source code in
@@ -600,14 +600,14 @@
     automatically extracting relevant software information from README files
   url: 'https://github.com/KnowledgeCaptureAndDiscovery/somef'
   catalog: TechRadar
-- id: somefvider
+- id: somef-vider
   name: SOMEF Vider
   description: >-
     Somef Vider is a web application that retrieves the metadata of the given
     GitHub repository through the Software Metadata Extraction Framework (SOMEF)
     and shows it in a user-friendly way.
   url: 'https://somef.linkeddata.es/'
-  catalog: RSQKit
+  catalog: TechRadar
 - id: readthedocs
   name: Read the Docs
   description: >-
@@ -852,8 +852,8 @@
   description: Bundler is a Ruby gems and environment management tool for Ruby projects.
   url: 'https://bundler.io/'
   catalog: RSQKit
-- id: fair-python-coockiecutter
-  name: FAIR Python Coockiecutter
+- id: fair-python-cookiecutter
+  name: FAIR Python Cookiecutter
   description: >-
     FAIR Python Cookiecutter is a cookiecutter template command-line tool to
     help you kickstart a modern best-practice Python project with FAIR metadata
@@ -1144,11 +1144,11 @@
     Software Management Wizard builds on the Data Stewardship Wizard (DSW) project to provide guided, structured support for creating and maintaining Software Management Plans (SMPs) throughout the software lifecycle. It enables teams to collaboratively produce SMPs that are both human-readable and machine-actionable, while aligning with community standards and supporting different types of research software.
   url: 'https://smw.dsw.elixir-europe.org/'
   catalog: RSQKit
-- id: autocodemeta
+- id: auto-codemeta
   name: Auto CodeMeta generator
   description: The Auto CodeMeta generator is a web application designed to simplify the creation of codemeta.json files, which are used to provide structured metadata for research software and code.
   url: https://autocodemeta.linkeddata.es/
-  catalog: RSQKit
+  catalog: TechRadar
 - name: flowR
   id: flowr
   description: >-
@@ -1199,8 +1199,8 @@
     and help to find memory leaks.
   url: 'https://memtt.github.io/malt/doc/latest/'
   catalog: TechRadar
-- id: renovate
-  name: renovate
+- id: renovatebot
+  name: renovate bot
   description: >-
     Automates dependency updates, multi-platform and multi-language.
   url: 'https://docs.renovatebot.com/'

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -26,7 +26,7 @@
 {%- if site.theme_variables.headings.resource-table-all-collapse %}
 <a data-bs-toggle="collapse" href="#tools_collapse" role="button" aria-expanded="false" aria-controls="tools_collapse" class="d-flex align-items-baseline pb-3 border-top info-collapse">
 {%- endif %}
-{% if site.theme_variables.headings.resource-table-all-collapse %}<h3 class="mb-0 mt-3 flex-grow-1 text-dark">{% else %}<h2 class="h2-like fs-2">{% endif %}{{site.theme_variables.headings.resource-table-all | default: 'Tools and resources on this page' }}{% if site.theme_variables.headings.resource-table-all-collapse %}</h3>{% else % %}</h2>{% endif %}
+{% if site.theme_variables.headings.resource-table-all-collapse %}<h3 class="mb-0 mt-3 flex-grow-1 text-dark">{% else %}<h2 class="h2-like fs-2">{% endif %}{{site.theme_variables.headings.resource-table-all | default: 'Tools and resources on this page' }}{% if site.theme_variables.headings.resource-table-all-collapse %}</h3>{% else %}</h2>{% endif %}
 {%- if site.theme_variables.headings.resource-table-all-collapse %}
 <i class="fa-solid fa-chevron-down fs-5"></i>
 </a>
@@ -49,11 +49,7 @@
 </th>
 <th>Description</th>
 <th>Related pages</th>
-<!--                <th>Registry {%- if include.tag -%}-->
-<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="Links to related information in ELIXIR registries: related policies and standards in FAIRsharing, scientific and technical descriptions of the resource in bio.tools, and related training in TeSS.">-->
-<!--                        <i class="fa-solid fa-info-circle"></i>-->
-<!--                    </a>{%- endif %}-->
-<!--                </th>-->
+<th>More about tool on TechRadar</th>
 </tr>
 </thead>
 <tbody>
@@ -83,9 +79,6 @@
     <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="{{tool.how_to_access}}"><span class="badge text-primary border border-primary"> <i class="fa-solid fa-key"></i></span></span>
     {%- endif %}
     {%- unless instances_tool == 0 or include.tag == nil %}
-    <!-- <a href="#national-resources-button">
-    <span class="badge text-white bg-primary"><i class="fa-solid fa-arrow-circle-down me-2"></i>Different instances available</span>
-</a> -->
     {%- endunless %}
 </div>
 {%- endif %}
@@ -99,23 +92,11 @@
 {%- endfor %}
 {%- endcapture %}
 <td>{{related_pages}}</td>
-<!--                <td>-->
-<!--                    {%- if tool.registry.biotools and tool.registry.biotools != "NA" %}-->
-<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="Bio.tools" href="https://bio.tools/{{tool.registry.biotools}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-info me-2"></i>Tool info</span></a>-->
-<!--                    {%- endif %}-->
-<!--                    {%- if tool.registry.fairsharing and tool.registry.fairsharing != "NA" %}-->
-<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>-->
-<!--                    {%- endif %}-->
-<!--                    {%- if tool.registry.fairsharing-coll and tool.registry.fairsharing-coll != "NA" %}-->
-<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing collection" href="https://fairsharing.org/{{tool.registry.fairsharing-coll}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>-->
-<!--                    {%- endif %}-->
-<!--                    {%- if tool.registry.tess and tool.registry.tess != "NA" %}-->
-<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="TeSS" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-graduation-cap me-2"></i>Training</span></a>-->
-<!--                    {%- endif %}-->
-<!--                    {%- if tool.registry.europmc and tool.registry.europmc != "NA" %}-->
-<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="EuroPMC" href="https://europepmc.org/article/MED/{{tool.registry.europmc}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-book me-2"></i>Publication</span></a>-->
-<!--                    {%- endif %}-->
-<!--                </td>-->
+<td>
+{%- if tool.catalog == "TechRadar" %}
+<a href="https://everse.software/TechRadar/#/tool/{{ tool.id }}" target="_blank" rel="noopener">View on TechRadar ↗</a>
+{%- endif %}
+</td>
 </tr>
 {%- endfor %}
 {%- if tool_matches_total == 0 or include.tag %}
@@ -148,15 +129,10 @@
 <table class="tooltable table display">
 <thead>
 <tr class="text-nowrap">
-<th>Tool or resource
-</th>
+<th>Tool or resource</th>
 <th>Description</th>
 <th>Related pages</th>
-<!--                <th>Registry-->
-<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="Links to related information in ELIXIR registries: related policies and standards in FAIRsharing, scientific and technical descriptions of the resource in bio.tools, and related training in TeSS.">-->
-<!--                        <i class="fa-solid fa-info-circle"></i>-->
-<!--                    </a>-->
-<!--                </th>-->
+<th>More about tool on TechRadar</th>
 </tr>
 </thead>
 <tbody>
@@ -204,23 +180,11 @@
 {%- else %}
 <td></td>
 {%- endif %}
-<!--                <td>-->
-<!--                    {%- if tool.registry.biotools and tool.registry.biotools != "NA" %}-->
-<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="Bio.tools" href="https://bio.tools/{{tool.registry.biotools}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-info me-2"></i>Tool info</span></a>-->
-<!--                    {%- endif %}-->
-<!--                    {%- if tool.registry.fairsharing and tool.registry.fairsharing != "NA" %}-->
-<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>-->
-<!--                    {%- endif %}-->
-<!--                    {%- if tool.registry.fairsharing-coll and tool.registry.fairsharing-coll != "NA" %}-->
-<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing collection" href="https://fairsharing.org/{{tool.registry.fairsharing-coll}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>-->
-<!--                    {%- endif %}-->
-<!--                    {%- if tool.registry.tess and tool.registry.tess != "NA" %}-->
-<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="TeSS" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-graduation-cap me-2"></i>Training</span></a>-->
-<!--                    {%- endif %}-->
-<!--                    {%- if tool.registry.europmc and tool.registry.europmc != "NA" %}-->
-<!--                    <a data-bs-toggle="tooltip" data-bs-original-title="EuroPMC" href="https://europepmc.org/article/MED/{{tool.registry.europmc}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-book me-2"></i>Publication</span></a>-->
-<!--                    {%- endif %}-->
-<!--                </td>-->
+<td>
+{%- if tool.catalog == "TechRadar" %}
+<a href="https://everse.software/TechRadar/#/tool/{{ tool.id }}" target="_blank" rel="noopener">View on TechRadar ↗</a>
+{%- endif %}
+</td>
 </tr>
 {%- endfor %}
 {%- endfor %}

--- a/pages/research_software_and_quality/life_cycle.md
+++ b/pages/research_software_and_quality/life_cycle.md
@@ -133,7 +133,7 @@ Research artifact archival focuses on preserving diverse and more general resear
 
 Software should be preserved in dedicated archival services that are separate from repositories used for development and release. 
 While platforms such as GitHub or GitLab are well suited to collaborative development - they are not designed to guarantee long-term preservation.
-Software archival require specialised long-term repositories like {% tool "softwareheritage" %} for computational reproducibility and unique identifiers (SWHIDs) to ensure the logic of scientific claims remains accessible and verifiable, treating code as a fundamental research output alongside papers and datasets. 
+Software archival require specialised long-term repositories like {% tool "software-heritage" %} for computational reproducibility and unique identifiers (SWHIDs) to ensure the logic of scientific claims remains accessible and verifiable, treating code as a fundamental research output alongside papers and datasets. 
 
 Archival services provide stable storage, persistent identifiers, curated metadata, and preservation policies that ensure software remains accessible and citable over time, even if development platforms, projects, or organisations change.
 Separating preservation from active software development therefore supports sustainability and reproducibility, and ensures that research software continues to deliver value and scholarly impact over time. 

--- a/pages/research_software_stories/dome_registry_research_software_story.md
+++ b/pages/research_software_stories/dome_registry_research_software_story.md
@@ -74,7 +74,7 @@ The project employs a well-integrated toolchain to ensure high software quality 
 * **Package Management:** Node Package Manager ([NPM](https://www.npmjs.com/)) handles dependencies.
 * **Productivity:** {% tool "github-copilot" %} is used to assist with developer productivity and accelerate progress.
 * **Containerisation:** Full containerisation with {% tool "docker" %} is planned but not yet implemented. Currently, the environment is managed via detailed setup instructions and version-locked dependencies (`package.json`) to ensure consistency across local setups.
-* **Future Plans:** {% tool "github-actions" %}, automated dependency updates ({% tool "dependabot" %} to maintain security with minimal effort), and AI code generation are being considered to accelerate development progress, though risks regarding codebase stability and knowledge retention are acknowledged.
+* **Future Plans:** {% tool "github_actions" %}, automated dependency updates ({% tool "dependabot" %} to maintain security with minimal effort), and AI code generation are being considered to accelerate development progress, though risks regarding codebase stability and knowledge retention are acknowledged.
 
 ## FAIR & Open 
 ### Adhering to FAIR principles for research software to ensure findability, accessibility, interoperability, and reusability

--- a/pages/research_software_stories/phoenix2_research_software_story.md
+++ b/pages/research_software_stories/phoenix2_research_software_story.md
@@ -38,7 +38,7 @@ Phoenix intends to be a generic base layer for research software, providing reli
 
 ## Technical Aspects
 
-The phoenix libraries are aiming to **facilitate the development and improve the quality** of data acquisition and data analysis software. Therefore, they include some field specific tools for data exchange between processes, abstract socket API with build-in mock-ups, serialization, ... but also a lot of general purpose utilities for research software: testing, benchmarking, configuration and argument parsing, string manipulation, code generation... Phoenix also provides a complete CI/CD workflow ({% tool "gitlab-ci-cd" %}) for projects managed with {% tool "pixi" %}.
+The phoenix libraries are aiming to **facilitate the development and improve the quality** of data acquisition and data analysis software. Therefore, they include some field specific tools for data exchange between processes, abstract socket API with build-in mock-ups, serialization, ... but also a lot of general purpose utilities for research software: testing, benchmarking, configuration and argument parsing, string manipulation, code generation... Phoenix also provides a complete CI/CD workflow ({% tool "gitlab-cicd" %}) for projects managed with {% tool "pixi" %}.
 
 Thanks to its modular design, a user interested in a specific subset of the features can install only the required packages, keeping their environment lightweight. Phoenix packages are implemented in either `C++`, `Rust` and `python` and packaged with {% tool "pixi" %} to the platform and language agnostic `conda` package format. Packages are available for the `linux-64` and `linux-aarch64` platforms. Additional platforms could be added upon request.
 
@@ -62,12 +62,12 @@ Phoenix packages mostly rely on the standard library of their language, but spec
 ## Software Practices
 ### Phoenix heavily leverages continuous integration and deployment best practices, and can help you do too!
 
-Phoenix strives to follow robust software development practices and heavily leverages {% tool "gitlab-ci-cd" %} [components](https://docs.gitlab.com/ci/components/) and {% tool "pixi" %}[tasks](https://pixi.prefix.dev/dev/workspace/advanced_tasks/) to standardize and automatize as many development and maintenance tasks as possible.
+Phoenix strives to follow robust software development practices and heavily leverages {% tool "gitlab-cicd" %} [components](https://docs.gitlab.com/ci/components/) and {% tool "pixi" %}[tasks](https://pixi.prefix.dev/dev/workspace/advanced_tasks/) to standardize and automatize as many development and maintenance tasks as possible.
 - The entire codebase is **version-controlled**.
 - **Continuous integration** validates the code, which is **thoroughly tested** by unit tests usually covering over 90% of the code.
 - Phoenix uses a **commit convention** that enables automatic detection of new releases according to [semantic versioning](https://semver.org/). 
 - Releases are built in CI/CD and deployed as `conda` packages and/or OCI containers, along with updated documentation. 
-- A {% tool "renovate" %} bot continuously monitors and updates dependencies, ensuring the codebase remains up to date. Code review is strongly encouraged.
+- A {% tool "renovatebot" %} bot continuously monitors and updates dependencies, ensuring the codebase remains up to date. Code review is strongly encouraged.
 - Phoenix CI/CD is centralized in [CI/CD catalogs](https://gitlab.in2p3.fr/CTA-LAPP/PHOENIX_LIBS2/citoolkit) that are available for usage in your own repositories!
 
 
@@ -97,7 +97,7 @@ In addition, Phoenix provides some tools to help developing high quality softwar
 - benchmarking tools to measure execution time of C++ routines
 - Reporter tool aggregating results from {% tool "maqao" %}, {% tool "valgrind" %}, {% tool "malt" %} and benchmarks
 - documentation generation from `LaTeX` or `markdown`
-- {% tool "gitlab-ci-cd" %} catalog relying on {% tool "pixi" %}[tasks](https://pixi.prefix.dev/dev/workspace/advanced_tasks/) to centralize CI/CD definitions.
+- {% tool "gitlab-cicd" %} catalog relying on {% tool "pixi" %}[tasks](https://pixi.prefix.dev/dev/workspace/advanced_tasks/) to centralize CI/CD definitions.
 
 
 ## FAIR & Open

--- a/pages/tasks/archiving_software.md
+++ b/pages/tasks/archiving_software.md
@@ -47,10 +47,10 @@ It requires addressing multiple interrelated technical aspects:
 
 Several archival solutions for research software are emerging:
 
-- {% tool "softwareheritage" %} can provide an universal archive of source code, capturing the development history of open-source software at scale.
+- {% tool "software-heritage" %} can provide an universal archive of source code, capturing the development history of open-source software at scale.
 - {% tool "reprozip" %} captures the execution environment of research software, enabling portability and reproducibility across platforms.
 - {% tool "guix" %} / {% tool "nixos" %} are functional package managers that enable reproducible builds and isolated software environments.
-- Containers (e.g., {% tool "docker" %}, {% tool "singularity" %}) are popular tools for bundling applications with dependencies, especially in high-performance computing.
+- Containers (e.g., {% tool "docker" %}, {% tool "singularityce" %}) are popular tools for bundling applications with dependencies, especially in high-performance computing.
 - VM snapshots are used when containerisation is not feasible, particularly for GUI-based or legacy software.
 - Institutional repositories and {% tool "zenodo" %} provide [DOI-backed software][software_identifiers] archiving linked to publications, ensuring persistent citation and access.
 - [RO-Crate](https://www.researchobject.org/ro-crate/) has an honourable mention here, while it is not an archival mechanism it is a critical metadata format that ensures items (e.g., [workflows](computational_workflows)) that are archived are described, understandable and reusable.

--- a/pages/tasks/ci_cd.md
+++ b/pages/tasks/ci_cd.md
@@ -53,14 +53,14 @@ CI/CD tools and platforms for different stages of code development and deploymen
 
 - Version Control Systems (VCS) are essential for managing code and version control. Some such tools (like GitHub, GitLab, Bitbucket)
   also provide CI/CD processes and services built around code repositories - e.g. [GitHub Actions][task_automation_github_actions], [GitLab CI/CD][task_automation_gitlab_ci_cd] and BitBucket Pipelines.
-    - Additional tools such as {% tool "precommit" %} can be used alongside VCS to ensure code quality is maintained.
+    - Additional tools such as {% tool "pre-commit" %} can be used alongside VCS to ensure code quality is maintained.
 - CI/CD pipelines - automate the entire process from code integration to deployment. Common tools include:
-    - {% tool "github-actions" %} - integrated CI/CD directly within GitHub, with [easy-to-set-up workflows (called actions)][task_automation_github_actions].
-    - {% tool "gitlab-ci-cd" %}: integrated CI/CD directly within GitLab.
+    - {% tool "github_actions" %} - integrated CI/CD directly within GitHub, with [easy-to-set-up workflows (called actions)][task_automation_github_actions].
+    - {% tool "gitlab-cicd" %}: integrated CI/CD directly within GitLab.
     - BitBucket Pipelines: integrated CI/CD directly within BitBucket.
     - {% tool "jenkins" %}: highly customisable and widely used for CI/CD pipelines.
     - CircleCI: focuses on simplicity and speed for building and testing.
-    - {% tool "travis" %}: a cloud-based CI service often used for open-source projects.
+    - {% tool "travis-ci" %}: a cloud-based CI service often used for open-source projects.
     - Azure Pipelines: part of the Azure DevOps suite, supports various languages and platforms.
 - Testing tools - automated testing tools like JUnit, Selenium, Cypress, and Postman integrate with CI/CD workflows/pipelines to ensure the code meets quality standards.
 - Artefact repositories - tools like Artifactory or Nexus Repository store build artefacts (e.g., Docker images, binaries) for deployment.

--- a/pages/tasks/complete_bibliographic_metadata_codemeta.md
+++ b/pages/tasks/complete_bibliographic_metadata_codemeta.md
@@ -33,9 +33,9 @@ For more on software metadata, check out the [Software Metadata](./software_meta
 
 - **Do It Yourself**: You can manually create the file using the CodeMeta schema. Check out the example below.
 - **Use Tools**:  
-  - {% tool "codemetagenerator" %} for a form-based approach  
+  - {% tool "codemeta-generator" %} for a form-based approach  
   - {% tool "somef" %} for command-line generation  
-  - {% tool "autocodemeta" %} for an interactive tool that guides you through creating a `codemeta.json` file step by step.
+  - {% tool "auto-codemeta" %} for an interactive tool that guides you through creating a `codemeta.json` file step by step.
   - NB Always review and add details like ORCID iDs and funder info.
 - **Archive Your Work**: Release your software on a platform that assigns DOIs, like {% tool "zenodo" %}. Add the DOI to your `codemeta.json` as an `identifier`.
 - **Validate**: Use a service like {% tool "jasonldvalidator" %} to ensure everything is correct.

--- a/pages/tasks/documenting_software_readthedocs.md
+++ b/pages/tasks/documenting_software_readthedocs.md
@@ -105,9 +105,9 @@ mkdocs:
 
 Integrate your project with Continuous Integration (CI) to automatically rebuild your documentation whenever changes are made:
 
-* {% tool "github-actions" %}: set up a workflow that triggers on every `push` or `pull request`. This helps automate the process of updating the documentation whenever you make changes to the source files.
+* {% tool "github_actions" %}: set up a workflow that triggers on every `push` or `pull request`. This helps automate the process of updating the documentation whenever you make changes to the source files.
 
-* {% tool "gitlab-ci-cd" %}: similarly to GitHub, you can configure GitLab CI pipelines to handle automatic updates.
+* {% tool "gitlab-cicd" %}: similarly to GitHub, you can configure GitLab CI pipelines to handle automatic updates.
 
 #### 6. Customise and Build Documentation
 

--- a/pages/tasks/fair_rs.md
+++ b/pages/tasks/fair_rs.md
@@ -30,7 +30,7 @@ Let's have a quick look into what each of the above principle means in practice.
 - [Create a description of your software][software_metadata] to make it discoverable by search engines and other search tools
 - Use standards (such as {% tool "codemeta" %}) to describe interoperable metadata for your software (see [Research Software Metadata Guidelines][rsmd-g1])
 - Place your software in a public software repository (and ideally register it in a [general-purpose or domain-specific software registry][software-registries])
-- Use a unique and persistent identifiers for your software, such as **Digital Object Identifiers** (DOIs) provided by {% tool "zenodo" %}, {% tool "figshare" %}, or **SoftWare Heritage persistent IDentifiers** ([SWHID](swhid)) provided by {% tool "softwareheritage" %}. 
+- Use a unique and persistent identifiers for your software, such as **Digital Object Identifiers** (DOIs) provided by {% tool "zenodo" %}, {% tool "figshare" %}, or **SoftWare Heritage persistent IDentifiers** ([SWHID](swhid)) provided by {% tool "software-heritage" %}. 
 In addition to findability of your software, identifiers can help you get credit for your work by providing citable references.
 - More broadly, use software sharing and collaborative platforms, as they facilitate code publication, sharing and findability:
   - general-purpose software repositories - {% tool "github" %} and {% tool "gitlab" %}

--- a/pages/tasks/organising_software_projects.md
+++ b/pages/tasks/organising_software_projects.md
@@ -90,10 +90,10 @@ project_name/
 
 For research projects that contain code, if you are using Python - check out the following two tools:
 
-- {% tool 'fair-python-coockiecutter' %} is a command-line template tool that can help you set up a Python software project skeleton that uses modern state-of-the-art development tools and helps you follow best practices for code and metadata quality. It generates project directories from predefined templates and ensures consistency by scaffolding a standardised project layout, including folders like `src/` for code, `tests/` for tests (shown below), and configuration files such as `pyproject.toml`, `README`, and `.gitignore`. This is especially helpful for teams or when starting new software projects, as it reduces setup time and enforces best practices.
+- {% tool 'fair-python-cookiecutter' %} is a command-line template tool that can help you set up a Python software project skeleton that uses modern state-of-the-art development tools and helps you follow best practices for code and metadata quality. It generates project directories from predefined templates and ensures consistency by scaffolding a standardised project layout, including folders like `src/` for code, `tests/` for tests (shown below), and configuration files such as `pyproject.toml`, `README`, and `.gitignore`. This is especially helpful for teams or when starting new software projects, as it reduces setup time and enforces best practices.
 -  {% tool "poetry" %} is a dependency and packaging manager that simplifies Python project management. It uses a single `pyproject.toml` file to declare dependencies, manage virtual environments, and handle versioning and publishing.
 In addition, {% tool "poetry" %} will also create a new directory with the necessary structure for you if you are starting a new Python project from scratch.
-{% tool "poetry" %} itself does not enforce a specific directory structure, but it encourages and works well with the "src layout" (shown below), which is a widely adopted best practice in modern Python development (as does {% tool 'fair-python-coockiecutter' %}).
+{% tool "poetry" %} itself does not enforce a specific directory structure, but it encourages and works well with the "src layout" (shown below), which is a widely adopted best practice in modern Python development (as does {% tool 'fair-python-cookiecutter' %}).
 
 ```
 project_name/

--- a/pages/tasks/packaging_software.md
+++ b/pages/tasks/packaging_software.md
@@ -40,7 +40,7 @@ Here are some common ways to package and release your software:
 They are often the first step toward an open release and packaging too - they allow storing and distributing packages across multiple programming languages and formats.
 * **Software registries and package repositories** – once your code is ready to be installed or reused, you can package and publish it to discipline- or language-specific registries (for example, PyPI for Python, CRAN for R, npm for JavaScript, Maven Central for Java). 
 These make it easy for users to install your software directly from their environment.
-* **Container registries and workflow hubs** – for more complex or reproducible environments, you can publish your software as a {% tool "docker" %}/{% tool "singularity" %} container or share it on workflow repositories (e.g. {% tool "workflowhub" %}, {% tool "dockstore" %}) to support reproducible execution.
+* **Container registries and workflow hubs** – for more complex or reproducible environments, you can publish your software as a {% tool "docker" %}/{% tool "singularityce" %} container or share it on workflow repositories (e.g. {% tool "workflowhub" %}, {% tool "dockstore" %}) to support reproducible execution.
 
 #### Code Hosting Platforms
 

--- a/pages/tasks/reproducible_software_environments.md
+++ b/pages/tasks/reproducible_software_environments.md
@@ -21,7 +21,7 @@ for specific programming languages, ensuring consistent behaviour of software ac
 Extremely useful when you are developing or modifying other people's software.
 - **Containerised environments** - use containers to encapsulate software and its dependencies, ensuring the software runs consistently across different systems regardless of the underlying host operating system.
   - {% tool "docker" %} - creates lightweight, isolated containers for packaging software and its dependencies.
-  - {% tool "singularity" %}, {% tool "apptainer" %} - focuses on containerisation for high-performance computing (HPC) and scientific computing.
+  - {% tool "singularityce" %}, {% tool "apptainer" %} - focuses on containerisation for high-performance computing (HPC) and scientific computing.
   - {% tool "docker-compose" %} - manages multi-container Docker applications, facilitating reproducible environments with multiple services.
 - **System-level environments** - work at the system level, ensuring that the entire system, including the operating system and application configurations, is reproducible.
   - {% tool "vagrant" %} - creates reproducible virtualised environments using configuration scripts to define virtual machines.

--- a/pages/tasks/software_metadata.md
+++ b/pages/tasks/software_metadata.md
@@ -78,7 +78,7 @@ See the [CodeMeta terms](https://codemeta.github.io/terms/) to understand which 
 
 - GitHub & GitLab code repositories support it to help document software for better discoverability.
 - Researchers use it to cite research software in academic papers.
-- Software repositories & archives like {% tool "zenodo" %}, {% tool "figshare" %}, {% tool "inveniordm" %} and {% tool "softwareheritage" %}, as well as many institutional repositories use it as a standardised metadata format across platforms.
+- Software repositories & archives like {% tool "zenodo" %}, {% tool "figshare" %}, {% tool "inveniordm" %} and {% tool "software-heritage" %}, as well as many institutional repositories use it as a standardised metadata format across platforms.
 - FAIR data initiatives support the use of CodeMeta format to [help with findability](https://zenodo.org/records/13996966/files/DASH_FAIR_CodeMeta_Oct_2024.pdf).
 
 ### How can you use CodeMeta?
@@ -86,12 +86,12 @@ See the [CodeMeta terms](https://codemeta.github.io/terms/) to understand which 
 You can use the [CodeMeta terms](https://codemeta.github.io/terms/) to create a `codemeta.json` file for your software projects and share it in the root of the source code repository (e.g. on GitHub & GitLab) along with your code.
 
 You can create the `codemeta.json` file:
-* by using {% tool "codemetagenerator" %}, an online form-based service to help you describe valid CodeMeta records.
+* by using {% tool "codemeta-generator" %}, an online form-based service to help you describe valid CodeMeta records.
 * by using {% tool "somef" %} command line tool and using the `-c` flag to export the CodeMeta file generated from your README file and available documentation. 
-Alternatively, {% tool "somefvider" %} will allow you to download auto-generated CodeMeta files (remember to double check the results).
+Alternatively, {% tool "somef-vider" %} will allow you to download auto-generated CodeMeta files (remember to double check the results).
 * manually, e.g. by using the [CodeMeta template](https://github.com/codemeta/codemeta/blob/master/codemeta.json) as a reference. JSON-LD files can be validated with services like {% tool "jasonldvalidator" %}.
 
-Using CodeMeta file to describe your software will propagate between different archival infrastructures, platforms and services which understand CodeMeta descriptions and can ingest existing `codemeta.json` files automatically ({% tool "zenodo" %}, {% tool "figshare" %}, {% tool "inveniordm" %} and {% tool "softwareheritage" %}).
+Using CodeMeta file to describe your software will propagate between different archival infrastructures, platforms and services which understand CodeMeta descriptions and can ingest existing `codemeta.json` files automatically ({% tool "zenodo" %}, {% tool "figshare" %}, {% tool "inveniordm" %} and {% tool "software-heritage" %}).
 This means you will not have to duplicate the work when using such services - e.g. when [obtaining a DOI for your software](./software_identifiers), if you have `codemeta.json` file already you will not have to fill in the corresponding software metadata again.
 
 {% assign child_pages = page.child_pages | join: ', ' %}

--- a/pages/tasks/task_automation_github_actions.md
+++ b/pages/tasks/task_automation_github_actions.md
@@ -12,7 +12,7 @@ keywords: ["ci cd", "ci/cd", "ci", "cd", "task automation", "github actions"]
 
 ### Description
 
-{% tool "github-actions" %} is a powerful [automation tool](https://docs.github.com/en/actions/about-github-actions/understanding-github-actions) ([continuous integration (CI)](https://docs.github.com/en/actions/about-github-actions/about-continuous-integration-with-github-actions) and [continuous delivery (CD)](https://docs.github.com/en/actions/about-github-actions/about-continuous-deployment-with-github-actions) platform) that allows you to define workflows (called `actions`) for your repository that help automate tasks such as building, testing and deploying code.
+{% tool "github_actions" %} is a powerful [automation tool](https://docs.github.com/en/actions/about-github-actions/understanding-github-actions) ([continuous integration (CI)](https://docs.github.com/en/actions/about-github-actions/about-continuous-integration-with-github-actions) and [continuous delivery (CD)](https://docs.github.com/en/actions/about-github-actions/about-continuous-deployment-with-github-actions) platform) that allows you to define workflows (called `actions`) for your repository that help automate tasks such as building, testing and deploying code.
 GitHub Actions enable you to streamline development processes and improve efficiency.
 
 ### Considerations

--- a/pages/tasks/task_automation_gitlab_ci_cd.md
+++ b/pages/tasks/task_automation_gitlab_ci_cd.md
@@ -14,9 +14,9 @@ keywords: ["ci cd", "ci/cd", "ci", "cd", "task automation", "gitlab ci/cd"]
 
 ### Description
 
-{% tool "gitlab-ci-cd" %} is the tool used in [GitLab hosted projects to run CI/CD pipelines][gitlab-ci-documentation].
+{% tool "gitlab-cicd" %} is the tool used in [GitLab hosted projects to run CI/CD pipelines][gitlab-ci-documentation].
 It is the equivalent of [Github Actions][task_automation_github_actions] for GitHub-hosted repositories.
-If you are interested in migrating your {% tool "github-actions" %} "actions" into GitLab CI/CD, you can follow the [GitLab-dedicated article on Github Actions migration](https://docs.gitlab.com/ci/migration/github_actions/).
+If you are interested in migrating your {% tool "github_actions" %} "actions" into GitLab CI/CD, you can follow the [GitLab-dedicated article on Github Actions migration](https://docs.gitlab.com/ci/migration/github_actions/).
 
 Why would you set up a GitLab CI/CD pipeline?
 It can help you automate:

--- a/pages/tasks/testing_software.md
+++ b/pages/tasks/testing_software.md
@@ -188,7 +188,7 @@ Hence, testing is an integral part and a widely accepted use case of CI.
 Testing in a CI pipeline goes one step further compared to the sole use of test automation frameworks.
 In addition to using the test automation framework locally and starting the execution of test within it manually, CI determines when and how to execute our test cases automatically and runs them on an integration machine.
 For example, as soon as a commit is pushed or a merge to a software development branch is performed, the integration machine starts a CI pipeline and executes the test cases and reports the test results in the so-called CI job log.
-Popular examples of CI infrastructures include {% tool "github-actions" %} and {% tool "gitlab-ci-cd" %}.
+Popular examples of CI infrastructures include {% tool "github_actions" %} and {% tool "gitlab-cicd" %}.
 
 ### Considerations
 


### PR DESCRIPTION
Fixes #500 #516 

Changes proposed in this pull request:

* Updated` resource-table-all.html `to include a new column titled “`More about tool on TechRadar`” on the resources page. This column provides links to TechRadar tools. A condition has been implemented using the catalog field so that when the catalog value is TechRadar, the table displays the link “`View on TechRadar.`”
* Updated `tool-and-resource-list.yaml `by modifying the existing id field values to align with TechRadar IDs for link generation. This approach was chosen to avoid introducing additional fields into the YAML structure.
* Replaced all occurrences of old ID values across task pages with the updated IDs.
* Performed minor spelling corrections throughout.

Below snapshot shows new look of resources page with TechRadar links

<img width="1489" height="586" alt="image" src="https://github.com/user-attachments/assets/a84890f3-3053-486e-9c0c-bac3a229be18" />


Notes for reviewers: 

* provide additional information for the reviewers here (if needed)
