### PR TITLE
A new page for Site Statistics fetched from Matomo APIs

### DIFF
--- a/.github/workflows/fetch-matomo-stats.yml
+++ b/.github/workflows/fetch-matomo-stats.yml
@@ -1,0 +1,40 @@
+name: Fetch Matomo Statistics
+
+on:
+  schedule:
+    - cron: '0 6 1 * *'    # runs first of each month at 6am UTC
+  workflow_dispatch:       
+  push:
+    branches: [main]       
+
+jobs:
+  fetch-stats:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Fetch Matomo stats
+        env:
+          MATOMO_URL:     ${{ secrets.MATOMO_URL }}      # optional — defaults to https://matomo.research.software/
+          MATOMO_SITE_ID: ${{ secrets.MATOMO_SITE_ID }}  # optional — defaults to 7
+          MATOMO_TOKEN:   ${{ secrets.MATOMO_TOKEN }}    # leave unset to use dummy data
+        run: python scripts/matomo_stats/fetch_matomo_stats.py
+
+      - name: Commit updated stats
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add _data/matomo_stats.json
+          git diff --cached --quiet && echo "No changes to commit" || \
+          git commit -m "chore: update Matomo visitor stats [skip ci]"
+          git push

--- a/.github/workflows/fetch-matomo-stats.yml
+++ b/.github/workflows/fetch-matomo-stats.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - "add_stats"
 
+permissions:
+  contents: write
+
 # Prevent overlapping runs
 concurrency:
   group: matomo-stats

--- a/.github/workflows/fetch-matomo-stats.yml
+++ b/.github/workflows/fetch-matomo-stats.yml
@@ -1,44 +1,69 @@
 name: Fetch Matomo Statistics
 
 on:
-  schedule:
-    - cron: '0 6 1 * *'    # runs first of each month at 6am UTC
-  workflow_dispatch:       
+schedule:
+- cron: '0 6 1 * *'  # first of each month at 06:00 UTC
+
+workflow_dispatch:
   push:
-    # branches: 
-    #   - main
     pull_request:
       branches:
-        - "add_stats"   
+      - "add_stats"
+
+# Prevent overlapping runs
+
+concurrency:
+group: matomo-stats
+cancel-in-progress: true
 
 jobs:
-  fetch-stats:
-    runs-on: ubuntu-latest
+fetch-stats:
+runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+steps:
+  - name: Checkout repo
+    uses: actions/checkout@v4
+    with:
+      fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
+  - name: Set up Python
+    uses: actions/setup-python@v5
+    with:
+      python-version: '3.11'
 
-      - name: Install dependencies
-        run: pip install requests
+  - name: Install dependencies
+    run: pip install requests
 
-      - name: Fetch Matomo Stats
-        env:
-          MATOMO_URL:     ${{ secrets.MATOMO_URL }}      # optional — defaults to https://matomo.research.software/
-          MATOMO_SITE_ID: ${{ secrets.MATOMO_SITE_ID }}  # optional — defaults to 7
-          MATOMO_TOKEN:   ${{ secrets.MATOMO_TOKEN }}    # if unset to uses dummy data
-        run: python scripts/matomo_stats/fetch_matomo_stats.py
+  - name: Fetch Matomo Stats
+    env:
+      MATOMO_URL: ${{ secrets.MATOMO_URL }}
+      MATOMO_SITE_ID: ${{ secrets.MATOMO_SITE_ID }}
+      MATOMO_TOKEN: ${{ secrets.MATOMO_TOKEN }}
+    run: python scripts/matomo_stats/fetch_matomo_stats.py
 
-      - name: Commit updated stats
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add _data/matomo_stats.json
-          git diff --cached --quiet && echo "No changes to commit" || \
-          git commit -m "chore: update Matomo visitor stats [skip ci]"
-          git push
+  - name: Commit and push if changed
+    run: |
+      git config user.name "github-actions[bot]"
+      git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      git add _data/matomo_stats.json
+
+      if git diff --cached --quiet; then
+        echo "No changes to commit"
+        exit 0
+      fi
+
+      git commit -m "Update Matomo site visitor statistics"
+
+      for i in 1 2 3; do
+        git pull --rebase --autostash
+        if git push; then
+          echo "Push succeeded"
+          exit 0
+        fi
+        echo "Push failed. Retrying ($i/3)..."
+        sleep 5
+      done
+
+      echo "Push failed after retries"
+      exit 1

--- a/.github/workflows/fetch-matomo-stats.yml
+++ b/.github/workflows/fetch-matomo-stats.yml
@@ -5,8 +5,8 @@ on:
     - cron: '0 6 1 * *'    # runs first of each month at 6am UTC
   workflow_dispatch:       
   push:
-    branches: 
-      - main
+    # branches: 
+    #   - main
     pull_request:
       branches:
         - "add_stats"   
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: pip install requests
 
-      - name: Fetch Matomo stats
+      - name: Fetch Matomo Stats
         env:
           MATOMO_URL:     ${{ secrets.MATOMO_URL }}      # optional — defaults to https://matomo.research.software/
           MATOMO_SITE_ID: ${{ secrets.MATOMO_SITE_ID }}  # optional — defaults to 7

--- a/.github/workflows/fetch-matomo-stats.yml
+++ b/.github/workflows/fetch-matomo-stats.yml
@@ -1,4 +1,4 @@
-name: Fetch Matomo Statistics
+name: Fetch Matomo statistics
 
 on:
   schedule:

--- a/.github/workflows/fetch-matomo-stats.yml
+++ b/.github/workflows/fetch-matomo-stats.yml
@@ -1,69 +1,68 @@
 name: Fetch Matomo Statistics
 
 on:
-schedule:
-- cron: '0 6 1 * *'  # first of each month at 06:00 UTC
-
-workflow_dispatch:
+  schedule:
+    - cron: '0 6 1 * *'  # first of each month at 06:00 UTC
+  workflow_dispatch:
   push:
-    pull_request:
-      branches:
+    branches:
+      - "add_stats"
+  pull_request:
+    branches:
       - "add_stats"
 
 # Prevent overlapping runs
-
 concurrency:
-group: matomo-stats
-cancel-in-progress: true
+  group: matomo-stats
+  cancel-in-progress: true
 
 jobs:
-fetch-stats:
-runs-on: ubuntu-latest
+  fetch-stats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-steps:
-  - name: Checkout repo
-    uses: actions/checkout@v4
-    with:
-      fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
-  - name: Set up Python
-    uses: actions/setup-python@v5
-    with:
-      python-version: '3.11'
+      - name: Install dependencies
+        run: pip install requests
 
-  - name: Install dependencies
-    run: pip install requests
+      - name: Fetch Matomo Stats
+        env:
+          MATOMO_URL: ${{ secrets.MATOMO_URL }}
+          MATOMO_SITE_ID: ${{ secrets.MATOMO_SITE_ID }}
+          MATOMO_TOKEN: ${{ secrets.MATOMO_TOKEN }}
+        run: python scripts/matomo_stats/fetch_matomo_stats.py
 
-  - name: Fetch Matomo Stats
-    env:
-      MATOMO_URL: ${{ secrets.MATOMO_URL }}
-      MATOMO_SITE_ID: ${{ secrets.MATOMO_SITE_ID }}
-      MATOMO_TOKEN: ${{ secrets.MATOMO_TOKEN }}
-    run: python scripts/matomo_stats/fetch_matomo_stats.py
-
-  - name: Commit and push if changed
-    run: |
-      git config user.name "github-actions[bot]"
-      git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      git add _data/matomo_stats.json
-
-      if git diff --cached --quiet; then
-        echo "No changes to commit"
-        exit 0
-      fi
-
-      git commit -m "Update Matomo site visitor statistics"
-
-      for i in 1 2 3; do
-        git pull --rebase --autostash
-        if git push; then
-          echo "Push succeeded"
-          exit 0
-        fi
-        echo "Push failed. Retrying ($i/3)..."
-        sleep 5
-      done
-
-      echo "Push failed after retries"
-      exit 1
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          git add _data/matomo_stats.json
+          
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          
+          git commit -m "Update Matomo site visitor statistics"
+          
+          for i in 1 2 3; do
+            git pull --rebase --autostash
+            if git push; then
+              echo "Push succeeded"
+              exit 0
+            fi
+            echo "Push failed. Retrying ($i/3)..."
+            sleep 5
+          done
+          
+          echo "Push failed after retries"
+          exit 1

--- a/.github/workflows/fetch-matomo-stats.yml
+++ b/.github/workflows/fetch-matomo-stats.yml
@@ -6,10 +6,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "add_stats"
-  pull_request:
-    branches:
-      - "add_stats"
+      - "main"
 
 permissions:
   contents: write

--- a/.github/workflows/fetch-matomo-stats.yml
+++ b/.github/workflows/fetch-matomo-stats.yml
@@ -5,7 +5,11 @@ on:
     - cron: '0 6 1 * *'    # runs first of each month at 6am UTC
   workflow_dispatch:       
   push:
-    branches: [main]       
+    branches: 
+      - main
+    pull_request:
+      branches:
+        - "add_stats"   
 
 jobs:
   fetch-stats:
@@ -27,7 +31,7 @@ jobs:
         env:
           MATOMO_URL:     ${{ secrets.MATOMO_URL }}      # optional — defaults to https://matomo.research.software/
           MATOMO_SITE_ID: ${{ secrets.MATOMO_SITE_ID }}  # optional — defaults to 7
-          MATOMO_TOKEN:   ${{ secrets.MATOMO_TOKEN }}    # leave unset to use dummy data
+          MATOMO_TOKEN:   ${{ secrets.MATOMO_TOKEN }}    # if unset to uses dummy data
         run: python scripts/matomo_stats/fetch_matomo_stats.py
 
       - name: Commit updated stats

--- a/_data/matomo_stats.json
+++ b/_data/matomo_stats.json
@@ -1,0 +1,7 @@
+{
+  "generated_at": "2026-05-06",
+  "total_visits": 0,
+  "total_unique_visitors": 0,
+  "top_countries": [],
+  "referrers": []
+}

--- a/_data/matomo_stats.json
+++ b/_data/matomo_stats.json
@@ -1,7 +1,69 @@
 {
   "generated_at": "2026-05-06",
-  "total_visits": 0,
-  "total_unique_visitors": 0,
-  "top_countries": [],
-  "referrers": []
+  "total_visits": 18472,
+  "total_unique_visitors": 11823,
+  "top_countries": [
+    {
+      "name": "United Kingdom",
+      "visits": 3241
+    },
+    {
+      "name": "Germany",
+      "visits": 2187
+    },
+    {
+      "name": "United States",
+      "visits": 1943
+    },
+    {
+      "name": "Netherlands",
+      "visits": 1502
+    },
+    {
+      "name": "France",
+      "visits": 987
+    },
+    {
+      "name": "Italy",
+      "visits": 834
+    },
+    {
+      "name": "Spain",
+      "visits": 721
+    },
+    {
+      "name": "Sweden",
+      "visits": 614
+    },
+    {
+      "name": "Switzerland",
+      "visits": 589
+    },
+    {
+      "name": "Australia",
+      "visits": 412
+    }
+  ],
+  "referrers": [
+    {
+      "type": "Direct Entry",
+      "visits": 6823
+    },
+    {
+      "type": "Search Engines",
+      "visits": 5341
+    },
+    {
+      "type": "Websites",
+      "visits": 4102
+    },
+    {
+      "type": "Social Networks",
+      "visits": 1876
+    },
+    {
+      "type": "Campaigns",
+      "visits": 330
+    }
+  ]
 }

--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -163,7 +163,7 @@ subitems:
         url: /contributors
       - title: List of all pages
         url: /all_pages
-  - title: Site stats
+  - title: Site Statistics
     url: /site_statistics
     description: Browse site statistics
 #  - title: All training resources

--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -163,5 +163,8 @@ subitems:
         url: /contributors
       - title: List of all pages
         url: /all_pages
+  - title: Site stats
+    url: /site_statistics
+    description: Browse site statistics
 #  - title: All training resources
 #    url: /all_training_resources

--- a/_includes/stats_widgets.html
+++ b/_includes/stats_widgets.html
@@ -1,0 +1,28 @@
+{% assign stats = site.data.matomo_stats %}
+<section class="visitor-stats" aria-label="Visitor statistics">
+  <h2>Site Statistics</h2>
+  <p class="stats-updated">Updated: {{ stats.generated_at }}</p>
+
+  <div class="stats-summary">
+    <div class="stat-card">
+      <span class="stat-number">{{ stats.total_visits | default: 0 }}</span>
+      <span class="stat-label">Total Visits</span>
+    </div>
+    <div class="stat-card">
+      <span class="stat-number">{{ stats.total_unique_visitors | default: 0 }}</span>
+      <span class="stat-label">Unique Visitors</span>
+    </div>
+  </div>
+
+  {% if stats.top_countries.size > 0 %}
+  <h3>Top Countries</h3>
+  <ul class="country-list">
+    {% for country in stats.top_countries limit:10 %}
+    <li>
+      <span class="country-name">{{ country.name }}</span>
+      <span class="country-visits">{{ country.visits }} visits</span>
+    </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+</section>

--- a/pages/site_statistics.md
+++ b/pages/site_statistics.md
@@ -2,4 +2,15 @@
 title: Site Statistics
 ---
 
+This page provides an overview of how the site is used and accessed. The statistics are collected using Matomo, an open-source analytics platform designed with privacy in mind.
+
+What we measure
+
+We collect aggregated, non-personal data to understand site usage, including:
+
+- Visitors – number of people accessing the site over time
+- Page views – total number of pages viewed
+- Referrers – how visitors arrive (e.g. search engines or direct links)
+- Geographic distribution – approximate visitor locations (country-level)
+
 {% include stats_widgets.html type="stats" search=true col=3 %}

--- a/pages/site_statistics.md
+++ b/pages/site_statistics.md
@@ -1,0 +1,5 @@
+---
+title: Site Statistics
+---
+
+{% include stats_widgets.html type="stats" search=true col=3 %}

--- a/scripts/matomo_stats/fetch_matomo_stats.py
+++ b/scripts/matomo_stats/fetch_matomo_stats.py
@@ -1,0 +1,106 @@
+import os
+import json
+import requests
+from datetime import date
+
+MATOMO_URL = os.environ.get("MATOMO_URL", "https://matomo.research.software/")
+SITE_ID    = os.environ.get("MATOMO_SITE_ID", "7")
+TOKEN      = os.environ.get("MATOMO_TOKEN", "")
+
+USE_DUMMY  = not TOKEN  # if no token, fall back to dummy data
+
+DUMMY_DATA = {
+    "generated_at": date.today().isoformat(),
+    "total_visits": 18472,
+    "total_unique_visitors": 11823,
+    "top_countries": [
+        { "name": "United Kingdom", "visits": 3241 },
+        { "name": "Germany",        "visits": 2187 },
+        { "name": "United States",  "visits": 1943 },
+        { "name": "Netherlands",    "visits": 1502 },
+        { "name": "France",         "visits": 987  },
+        { "name": "Italy",          "visits": 834  },
+        { "name": "Spain",          "visits": 721  },
+        { "name": "Sweden",         "visits": 614  },
+        { "name": "Switzerland",    "visits": 589  },
+        { "name": "Australia",      "visits": 412  }
+    ],
+    "referrers": [
+        { "type": "Direct Entry",   "visits": 6823 },
+        { "type": "Search Engines", "visits": 5341 },
+        { "type": "Websites",       "visits": 4102 },
+        { "type": "Social Networks","visits": 1876 },
+        { "type": "Campaigns",      "visits": 330  }
+    ]
+}
+
+
+def api(method, extra=""):
+    url = (
+        f"{MATOMO_URL}?module=API&method={method}"
+        f"&idSite={SITE_ID}&format=JSON&token_auth={TOKEN}{extra}"
+    )
+    r = requests.get(url, timeout=30)
+    r.raise_for_status()
+    data = r.json()
+    if isinstance(data, dict) and data.get("result") == "error":
+        raise RuntimeError(f"Matomo API error: {data.get('message')}")
+    return data
+
+
+def fetch_live():
+    print("Fetching live data from Matomo...")
+
+    summary = api(
+        "VisitsSummary.get",
+        "&period=range&date=2000-01-01,today"
+    )
+
+    countries = api(
+        "UserCountry.getCountry",
+        "&period=range&date=last365&filter_limit=15"
+    )
+
+    referrers = api(
+        "Referrers.getReferrerType",
+        "&period=range&date=last365"
+    )
+
+    return {
+        "generated_at":          date.today().isoformat(),
+        "total_visits":          summary.get("nb_visits", 0),
+        "total_unique_visitors": summary.get("nb_uniq_visitors", 0),
+        "top_countries": [
+            {"name": c["label"], "visits": c["nb_visits"]}
+            for c in (countries if isinstance(countries, list) else [])
+        ],
+        "referrers": [
+            {"type": r["label"], "visits": r["nb_visits"]}
+            for r in (referrers if isinstance(referrers, list) else [])
+        ]
+    }
+
+
+def main():
+    if USE_DUMMY:
+        print("No MATOMO_TOKEN set — using dummy data.")
+        output = DUMMY_DATA
+    else:
+        try:
+            output = fetch_live()
+            print(f"Live data fetched. Total visits: {output['total_visits']}")
+        except Exception as e:
+            print(f"WARNING: Matomo fetch failed ({e}). Falling back to dummy data.")
+            output = DUMMY_DATA
+
+    out_path = os.path.join(
+        os.path.dirname(__file__), "../_data/matomo_stats.json"
+    )
+    with open(out_path, "w") as f:
+        json.dump(output, f, indent=2)
+
+    print(f"Written to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/matomo_stats/fetch_matomo_stats.py
+++ b/scripts/matomo_stats/fetch_matomo_stats.py
@@ -94,7 +94,7 @@ def main():
             output = DUMMY_DATA
 
     out_path = os.path.join(
-        os.path.dirname(__file__), "../_data/matomo_stats.json"
+        os.path.dirname(__file__), "../../_data/matomo_stats.json"
     )
     with open(out_path, "w") as f:
         json.dump(output, f, indent=2)


### PR DESCRIPTION
Fixes #588 #615 

Changes proposed in this pull request:

**Approach**

Fetch data at build time from Matomo APIs via a python script, write it to a` _data/matomo_stats.json` file, then render it on a new RSQKit page - `Site Statistics` via Liquid templates. 
Schedule the run for monthly stats.

It is consistent with how RSQKit already uses _data/ for YAML data files.

Env variables to set : `MATOMO_URL`, `SITE_ID`, `TOKEN` 

**Implementation**

* A python script - to fetch stats via matomo APIs
* It stores data at - _data/matomo_stats.json
* Added workflow to run 1st for every month at 6 am to fetch stats
* Created a html for new page `Site Statistics`

Notes for reviewers: 

* @shoaibsufi Please review the approach and suggest if this is okay :) Also could you help me with icon image for Site Stats.
For now I have not set TOKEN, so for testing I have fed stats default values to show. Once I get token, real stats values would start appearing on Site Statistics page.


