### PR TITLE
Matching on keywords rather than free text search to improve training relevance on task pages

### DIFF
--- a/_includes/more-information-tiles.html
+++ b/_includes/more-information-tiles.html
@@ -71,7 +71,7 @@
                                     pageSize: 5,
                                     keywords: {{ page.keywords | jsonify }}
                                 },
-                                baseUrl: '{{ training.url }}', 
+                                baseUrl: '{{ training.url }}',
                                 instanceName: '{{ training.name }}'
                             });
                     }

--- a/_includes/more-information-tiles.html
+++ b/_includes/more-information-tiles.html
@@ -69,7 +69,7 @@
                                 },
                                 params: {
                                     pageSize: 5,
-                                    q: '{{ page.keywords | join: " OR " }}'
+                                    keywords: {{ page.keywords | jsonify }}
                                 },
                                 baseUrl: '{{ training.url }}',
                                 instanceName: '{{ training.name }}'

--- a/_includes/more-information-tiles.html
+++ b/_includes/more-information-tiles.html
@@ -71,7 +71,7 @@
                                     pageSize: 5,
                                     keywords: {{ page.keywords | jsonify }}
                                 },
-                                baseUrl: '{{ training.url }}',
+                                baseUrl: '{{ training.url }}', 
                                 instanceName: '{{ training.name }}'
                             });
                     }

--- a/pages/contributing/metadata_guidelines.md
+++ b/pages/contributing/metadata_guidelines.md
@@ -1,7 +1,7 @@
 ---
 title: Metadata Guidelines
 summary: Descriptions of different metadata schemas used to describe various resources and pages in RSQKit.
-contributors: ["Aleksandra Nenadic", "Daniel Garijo", "Shoaib Sufi"]
+contributors: ["Aleksandra Nenadic", "Daniel Garijo", "Shoaib Sufi", "Kenneth Rioja"]
 ---
 
 This page explains the metadata that can be used to describe various resources and pages in RSQKit.
@@ -185,6 +185,8 @@ An example of an RS Quality dimension definition is given below:
 
 ## Training metadata
 
+### In RSQKit
+
 Metadata about various training registries that RSQKit can integrate with is located in the `_config.yml` file in the project root.
 It can be configured via the following attribute:
 
@@ -199,3 +201,9 @@ training:
    - name: "EVERSE TeSS"
      url: "https://everse-training.app.cern.ch"
 ```
+
+### In EVERSE Training
+
+One can manually register a training material in [EVERSE Training](https://everse-training.app.cern.ch/). To make your material findable, keywords need to be properly describing your material. While registering your training material, we highly recommend to select keywords coming from the EVERSE [curated list for keywords](https://github.com/EVERSE-ResearchSoftware/training/blob/main/csv/keywords.csv). If your material is described with keywords from this list, it will be listed under the `Training` sections of relevant RSQKit pages. 
+
+For example, if your material is about reproducibility, including 'reproducibility' as one of the keywords in EVERSE Training will result in having your material featured in the [Reproducible software environments](https://everse.software/RSQKit/reproducible_software_environments) page from the RSQKit. Contact <contact.eversetraining@cern.ch> for more information.

--- a/pages/contributing/metadata_guidelines.md
+++ b/pages/contributing/metadata_guidelines.md
@@ -204,6 +204,6 @@ training:
 
 ### In EVERSE Training
 
-One can manually register a training material in [EVERSE Training](https://everse-training.app.cern.ch/). To make your material findable, keywords need to be properly describing your material. While registering your training material, we highly recommend to select keywords coming from the EVERSE [curated list for keywords](https://github.com/EVERSE-ResearchSoftware/training/blob/main/csv/keywords.csv). If your material is described with keywords from this list, it will be listed under the `Training` sections of relevant RSQKit pages. 
+One can manually register a training material in [EVERSE Training](https://everse-training.app.cern.ch/). To make your material findable, you should use appropriate keywords to describe your material at the time of registering it. It is highly recommend to select keywords from the [EVERSE curated list for keywords](https://github.com/EVERSE-ResearchSoftware/training/blob/main/csv/keywords.csv), in which case it will be listed under the `Training` sections of relevant RSQKit pages that are described using the same keywords in their metadata. 
 
 For example, if your material is about reproducibility, including 'reproducibility' as one of the keywords in EVERSE Training will result in having your material featured in the [Reproducible software environments](https://everse.software/RSQKit/reproducible_software_environments) page from the RSQKit. Contact <contact.eversetraining@cern.ch> for more information.


### PR DESCRIPTION
Before creating a pull request:

- *Please make sure you have checked [Contributing Guidelines](https://everse.software/RSQKit/page_style_guidelines).*
- *Please maek sure you have checked [Page Style Guidelines](https://everse.software/RSQKit/page_style_guidelines) and [checked for typos and spelling mistakes](https://everse.software/RSQKit/contribution_guidelines#spelling-check).*
- *Is there a related issue for the fix you are providing? If not, please consider adding one.*
- *If you are changing files in `data/` or `_includes` folder or `config.yaml` file - please make sure you have discussed this with the maintainers in the relevant issue.*

Fixes #657

Changes proposed in this pull request:

* In the EVERSE Training (TeSS) widget, I changed `q:` (query) to `keywords:` -> this allows a strict search on the keywords

Notes for reviewers: 

* I added in metadata guidelines a section for EVERSE Training after [Daniel's suggestion](https://github.com/EVERSE-ResearchSoftware/RSQKit/issues/657#issuecomment-4621933455)
