### PR TITLE
Remove links to dimensions on TechRadar and replace them with links to Dimension & Indicators site

### DIFF
--- a/_includes/dimensions.html
+++ b/_includes/dimensions.html
@@ -2,6 +2,5 @@
 <h3>{{ item.name }}</h3>
 <p>
     {{ item.description | markdownify }}
-    Read more about <strong>{{ item.name | downcase }} dimension</strong> on <a href="https://everse.software/TechRadar/{{ item.name | slugify: 'raw' | replace: '-', '_' | downcase }}">TechRadar</a>.
 </p>
 {% endfor %}

--- a/_includes/dimensions.html
+++ b/_includes/dimensions.html
@@ -2,5 +2,6 @@
 <h3>{{ item.name }}</h3>
 <p>
     {{ item.description | markdownify }}
+    See the <a href="https://everse.software/indicators/website/dimensions.html#{{ item.name | slugify: 'raw' | replace: '-', '_' | downcase }}">official dimension entry for <strong>{{ item.name | downcase }}</strong></a> on the <a href="https://everse.software/indicators/website/dimensions.html">Dimensions & Indicators site</a>.
 </p>
 {% endfor %}


### PR DESCRIPTION
Fixes #662.