### PR TITLE
editing "Trainer" role first paragraph.md

### DIFF
--- a/pages/roles/trainer.md
+++ b/pages/roles/trainer.md
@@ -5,7 +5,9 @@ contributors: ["Aleksandra Nenadic"]
 page_id: trainer
 ---
 
-## Introduction As a trainer, you design or deliver training courses in research software development and quality for specific research domain or in general.
+## Introduction 
+
+As a trainer, you design or deliver training courses in research software development and quality for a specific research domain or in general.
 
 Your primary audience is PhD students, postdocs, researchers and technicians [who code](./researcher_who_codes) or early career [Research Software Engineers (RSEs)](./research_software_engineer).
 


### PR DESCRIPTION
I edited  the first paragraph of the Trainer role page [https://everse.software/RSQKit/trainer](https://everse.software/RSQKit/trainer)  "_As a trainer, you design or deliver training courses in research software development and quality for specific research domain or in general._" so it is no longer part of the heading "Introduction".

<img width="1722" height="820" alt="Screenshot 2026-06-24 at 17-25-34 roles Trainer RSQKit Research Software Quality Kit" src="https://github.com/user-attachments/assets/8e39b5b9-7f57-415c-9d5c-1419fb94b507" />
