### PR TITLE
Add TechRadar Dimensions Tool Links to the RSQKit Page

### DIFF
--- a/_includes/dimensions.html
+++ b/_includes/dimensions.html
@@ -1,7 +1,25 @@
+```liquid id="v4k8qm"
 {% for item in site.data.quality_dimensions %}
 <h3>{{ item.name }}</h3>
 <p>
     {{ item.description | markdownify }}
-    See the <a href="https://everse.software/indicators/website/dimensions.html#{{ item.name | slugify: 'raw' | replace: '-', '_' | downcase }}">official dimension entry for <strong>{{ item.name | downcase }}</strong></a> on the <a href="https://everse.software/indicators/website/dimensions.html">Dimensions & Indicators site</a>.
+    See the
+    <a href="https://everse.software/indicators/website/dimensions.html#{{ item.name | slugify: 'raw' | replace: '-', '_' | downcase }}">
+        official dimension entry for <strong>{{ item.name | downcase }}</strong>
+    </a>
+    on the
+    <a href="https://everse.software/indicators/website/dimensions.html">
+        Dimensions & Indicators site
+    </a>.
 </p>
+
+{% unless item.name == "Community" %}
+<p>
+        <a href="https://everse.software/TechRadar/#/?dimension={{ item.name | slugify: 'raw' | downcase }}">
+            Explore quality tools for this dimension on <strong>TechRadar</strong> →
+        </a>
+</p>
+{% endunless %}
+
 {% endfor %}
+```


### PR DESCRIPTION
Fixes #705 

Changes proposed in this pull request:

* Added TechRadar quality tool links for each dimension.
* Added the TechRadar links as separate call-to-action links.

This is how dimensions page looks, after the changes

<img width="1606" height="797" alt="image" src="https://github.com/user-attachments/assets/315b4a25-db1e-4c8c-be7a-17dbda7883a3" />
