### PR TITLE
Mps fix docker compose no origin from git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ruby:3.3.7
 WORKDIR /usr/src/app
+# Necessary to be able to detect remote origin
+RUN apt-get update && apt-get install -y git
+RUN git config --global --add safe.directory /usr/src/site
 RUN gem install bundler jekyll
 COPY Gemfile* ./
 RUN bundle install

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,10 +78,3 @@ docker-compose up
 
 You should now be able to access your local copy of RSQKit on <http://127.0.0.1:4000>.
 
-If you experience a message error like `jekyll-1 | Liquid Exception: No repo name found.`, it might be that Jekyll cannot find the `origin` Git remote pointing to your github.com repository. 
-To fix this error, you can either:
-
-- Rename your local Git remote to `origin`. Do `git remote -v` to see the list of remotes, then `git remote rename <old-name-current-repo> origin`, or
-- Add `repository: EVERSE-ResearchSoftware RSQKit` line to `_config.yml`.
-
-Then re-run the previous two `docker-compose` commands.


### PR DESCRIPTION
This fixes #707 

The fix for #530 from #624 suggests the fix for

    * `jekyll-1 | Liquid Exception: No repo name found`

is to modify the config, but the issue exists because git isn't
available, configured and usabel inside the repo.

This PR fixes that root cause, removing the need to change
the config and removes the now unnecessary guidance.

Changes proposed in this pull request:

* Changes the Dockerfile to enable git to run correctly inside the docker container
* This enable ETT to find the repo name
* Removes the guidance around this as a result.

Notes for reviewers: 

* Will be merging this after creating because blocks docker based development - so the review requests is for a post-hoc review if needed.