### PR TITLE
Removing redundancies in sw metadata page

### DIFF
--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -116,8 +116,8 @@ subitems:
       - title: "Software metadata"
         url: /software_metadata
         subitems:
-          - title: "Creating bibliographic metadata with CodeMeta"
-            url: /complete_bibliographic_metadata_codemeta
+          - title: "Creating software metadata with CodeMeta"
+            url: /complete_software_metadata_codemeta
       - title: "Packaging software"
         url: /packaging_software
       - title: "Performance profiling and optimization"

--- a/pages/tasks/complete_software_metadata_codemeta.md
+++ b/pages/tasks/complete_software_metadata_codemeta.md
@@ -1,7 +1,8 @@
 ---
 title: "Creating software metadata with CodeMeta"
 description: "Guidance on creating a CodeMeta file for software projects."
-contributors: ["Gavin J. Pringle", "Daniel Garijo"] # Add contributors' names here
+contributors: ["Gavin Pringle", "Daniel Garijo"] # Add contributors' names here
+coordinators: ["Gavin Pringle"]
 page_id: complete_software_metadata_codemeta
 related_pages:
   your_tasks: [software_metadata]

--- a/pages/tasks/complete_software_metadata_codemeta.md
+++ b/pages/tasks/complete_software_metadata_codemeta.md
@@ -1,8 +1,8 @@
 ---
-title: "Creating bibliographic metadata with CodeMeta"
+title: "Creating software metadata with CodeMeta"
 description: "Guidance on creating a CodeMeta file for software projects."
-contributors: ["Gavin J. Pringle"] # Add contributors' names here
-page_id: complete_bibliographic_metadata_codemeta
+contributors: ["Gavin J. Pringle", "Daniel Garijo"] # Add contributors' names here
+page_id: complete_software_metadata_codemeta
 related_pages:
   your_tasks: [software_metadata]
 quality_indicators: [codemeta_completeness, descriptive_metadata] # Add relevant quality indicators here
@@ -11,9 +11,19 @@ keywords: ["codemeta", "bibliographic metadata", "software citation"]
 
 ### Description 
 
-Creating a `codemeta.json` file is like giving your software a passport. 
-It makes your project easy to find, cite, and use. 
-This file helps others understand what your software does and who contributed to it.
+{% tool "codemeta" %} is a community-developed metadata standard designed to describe and exchange metadata about research software projects in a structured way.
+It provides a machine-readable JSON-LD format (in the form of `codemeta.json` file attached to your software project) for storing metadata about software, including authorship, licensing, dependencies, versioning, and more.
+It consists of a set of properties that extend [Schema.org](https://schema.org) (a popular metadata vocabulary designed to describe Digital Objects on the Web) with software-specific metadata (e.g. maintainer, build instructions, software documentation, etc.).
+
+Creating a `codemeta.json` file is like giving your software a passport. It was created to standardise metadata across different repositories and programming ecosystems, making it easier to share, discover, and cite software.
+See the [CodeMeta terms](https://codemeta.github.io/terms/) to understand which terms are used to describe software.
+
+### Who uses CodeMeta?
+
+- GitHub & GitLab code repositories support it to help document software for better discoverability.
+- Researchers use it to cite research software in academic papers.
+- Software repositories & archives like {% tool "zenodo" %}, {% tool "figshare" %}, {% tool "inveniordm" %} and {% tool "software-heritage" %}, as well as many institutional repositories use it as a standardised metadata format across platforms.
+- FAIR data initiatives support the use of CodeMeta format to [help with findability](https://zenodo.org/records/13996966/files/DASH_FAIR_CodeMeta_Oct_2024.pdf).
 
 ### Considerations 
 
@@ -22,7 +32,7 @@ When you're setting up a `codemeta.json` file, keep these things in mind:
 - **Keep It Current**: Update the file whenever your software changes. New version? New contributor? Make sure it's reflected.
 - **Check for Errors**: Use a JSON-LD validator to catch any mistakes, e.g., {% tool "jasonldvalidator" %}.
 - **Use Persistent Identifiers**: Add a Digital Object Identifier (DOI) for the software release itself for long-term citation (e.g., from Zenodo). Ensure ORCID iDs are included for all people.
-- **Link to the Paper**: Use the `referencePublication` property to link to the corresponding journal article, including the paper's DOI as its `identifier`.
+- **Link to a Publication**: Use the `referencePublication` property to link to the corresponding journal article, including the paper's DOI as its `identifier`.
 - **Detail Contributors**: Use the `Person` schema and include ORCID iDs (the persistent identifier for people) for authors and contributors.
 - **Clarify Licensing**: Use a Software Package Data Exchange (SPDX) identifier to make the license clear.
 - **Acknowledge Funders**: Include funder details with identifiers like Crossref Funder IDs.
@@ -31,12 +41,14 @@ For more on software metadata, check out the [Software Metadata](./software_meta
 
 ### Solutions 
 
-- **Do It Yourself**: You can manually create the file using the CodeMeta schema. Check out the example below.
+- **Do It Yourself**: You can manually create the file using the CodeMeta schema. Check out the example below, or use the [CodeMeta template](https://github.com/codemeta/codemeta/blob/master/codemeta.json) as a reference. JSON-LD files can be validated with services like {% tool "jasonldvalidator" %}
 - **Use Tools**:  
-  - {% tool "codemeta-generator" %} for a form-based approach  
+  - {% tool "codemeta-generator" %} for a manual form-based approach  
+  - {% tool "auto-codemeta" %} for an interactive tool that helps you create a `codemeta.json` file step by step by retrieving existing metadata in your code repository.
   - {% tool "somef" %} for command-line generation  
-  - {% tool "auto-codemeta" %} for an interactive tool that guides you through creating a `codemeta.json` file step by step.
-  - NB Always review and add details like ORCID iDs and funder info.
+  - {% tool "somef-vider" %} will allow you to download auto-generated CodeMeta files (remember to double check the results).
+  
+  - Always review and add details like ORCID iDs and funder information.
 - **Archive Your Work**: Release your software on a platform that assigns DOIs, like {% tool "zenodo" %}. Add the DOI to your `codemeta.json` as an `identifier`.
 - **Validate**: Use a service like {% tool "jasonldvalidator" %} to ensure everything is correct.
 
@@ -46,7 +58,7 @@ Here's a sample `codemeta.json` file to get you started:
 
 ```json
 {
-  "@context": "https://doi.org/10.5063/schema/codemeta-3.1",
+  "@context": "https://w3id.org/codemeta/3.0",
   "@type": "SoftwareSourceCode",
   "name": "Your Software Name",
   "description": "A brief description of your software.",
@@ -54,7 +66,7 @@ Here's a sample `codemeta.json` file to get you started:
   "referencePublication": {
     "@type": "ScholarlyArticle",
     "headline": "A New Algorithm for Applied Mathematics using Python and NumPy",
-    "identifier": "https://doi.org/10.1016/j.jsc.2023.10.001",
+    "identifier": "https://doi.org/10.1016/j.jsc.2023.10.001"
   },
 "author": [
     {
@@ -80,7 +92,7 @@ Here's a sample `codemeta.json` file to get you started:
       "@type": "Person",
       "givenName": "Key",
       "familyName": "Contributor",
-      "identifier": "https://orcid.org/0000-0001-9999-9999",
+      "identifier": "https://orcid.org/0000-0001-9999-9999"
     }
   ],
   "license": "https://spdx.org/licenses/MIT",
@@ -91,8 +103,8 @@ Here's a sample `codemeta.json` file to get you started:
   "dateCreated": "2023-10-01",
   "dateModified": "2023-10-10",
   "softwareRequirements": [
-    "numpy",
-    "pandas"
+    "numpy = 2.5.2",
+    "pandas = 3.0.5"
   ],
   "relatedLink": "https://yourwebsite.com",
   "identifier": "https://doi.org/10.1234/exampledoi",
@@ -102,7 +114,8 @@ Here's a sample `codemeta.json` file to get you started:
       "name": "Funder Name",
       "identifier": "https://doi.org/10.13039/100000001"
     }
-  ]
+  ],
+  "funding":"Grant number"
 }
 ```
 By following these steps, you can provide complete bibliographic metadata for your software project in a CodeMeta file, enhancing its discoverability and citation.

--- a/pages/tasks/software_metadata.md
+++ b/pages/tasks/software_metadata.md
@@ -4,9 +4,9 @@ description: How to describe your software using metadata?
 contributors: ["Daniel Garijo", "Aleksandra Nenadic"]
 page_id: software_metadata
 related_pages:
-  tasks: [software_identifiers]
+  tasks: [software_identifiers, citing_software, archiving_software]
 quality_indicators: [descriptive_metadata, codemeta_completeness]
-child_pages: [complete_bibliographic_metadata_codemeta]
+child_pages: [complete_software_metadata_codemeta]
 keywords: ["software metadata", "codemeta", "software citation", "cff"]
 
 ---
@@ -16,16 +16,17 @@ keywords: ["software metadata", "codemeta", "software citation", "cff"]
 Software metadata is structured data that provides information about a software application, its components, and its behaviour.
 It describes various attributes of the software, including:
 
-- Name & version: identifies the software and its release version.
 - Authors: details about the developers or organisations that created the software.
-- Dependencies: lists required libraries, frameworks, or other software needed for proper functioning.
-- License: specifies the software license (e.g., MIT, BSD, GPL, proprietary).
 - Build & runtime information: includes details like operating system compatibility, architecture (e.g., 32-bit or 64-bit), and runtime requirements.
+- Dependencies: lists required libraries, frameworks, or other software needed for proper functioning.
+- Description and keywords: details about what the software tool does, its features and purpose.
+- License: specifies the software license (e.g., MIT, BSD, GPL, proprietary).
+- Name & version: identifies the software and its release version.
 - Support and maintenance information: contact details to get support and questions answered.
 
 ### Considerations
 
-Providing metadata with your software is important because it provides the crucial context and (typically machine readable) information about your software and its components, enhancing its discoverability, reusability and interoperability with other tools.
+Providing metadata with your software is important because it provides the crucial context and (typically machine readable) information about your software and its components, enhancing its discoverability, reusability and interoperability with other tools. Software metadata is key to addressing many of the FAIR principles.
 
 The type of metadata you need from software depends on your specific use case.
 
@@ -33,15 +34,16 @@ The type of metadata you need from software depends on your specific use case.
 - If you're aiming to replicate an analysis, versioning and dependencies matter more than authorship or titles.
 - If you're searching for new software suited to a particular task, keywords and descriptions are most relevant.
 
-Often, developers of scientific software, repositories that host it, and users have multiple objectives—sometimes balancing several of these needs at once.
+Often, developers of researcg software, repositories that host it, and users have multiple objectives—sometimes balancing several of these needs at once.
 
 ### Solutions
 
-There are various kinds of software metadata standards with slightly different purposes and use cases, some of which are listed below.
+Include a metadata file together with your source code files. There are various kinds of software metadata standards with slightly different purposes and use cases, some of which are listed below.
 
 General software metadata standards, for example:
 
-- {% tool "codemeta" %} – a standardised JSON-LD metadata format for describing software projects to support the preservation, discovery, reuse, and attribution of research software.
+- {% tool "codemeta" %} – a community standard JSON-LD metadata format for describing software projects to support the preservation, discovery, reuse, and attribution of research software. See our dedicated [page](complete_bibliographic_metadata_codemeta) for learning how to add a CodeMeta file in you repository.
+- [Citation File Format](https://citation-file-format.github.io/) a metadata file for supporting software citation  purposes. See our dedicated [page](citing_software) for learning how to add a CFF file in your code repository.
 - {% tool "spdx" %} – used for documenting software licenses, components, and security information.
 - [Dublin Core](https://www.dublincore.org/) – a general purpose metadata standard and vocabulary for describing resources of any type 
 (first developed for describing web content in the early days of the World Wide Web), now often used for software documentation.
@@ -54,6 +56,10 @@ For example:
 - PyPI metadata (Python) - `setup.py` and `pyproject.toml` define package metadata for Python packages and projects.
 - `pom.xml` (Maven – Java) - defines project dependencies, build configurations, and plugins in Java projects.
 - `package.json` (Node.js / npm) - manages dependencies, scripts, and metadata for JavaScript projects.
+- `Cargo.toml` - manages dependencies, scripts, and metadata for Rust projects.
+- `Project.toml` - manages dependencies, scripts, and metadata for Julia projects.
+- `DESCRIPTION` - manages dependencies, scripts, and metadata for R projects.
+- `composer.json` - manages dependencies, scripts, and metadata for PHP projects.
 - interoperability & integration metadata (e.g. [BioSchemas Computational Tool profile](https://bioschemas.org/profiles/ComputationalTool/1.1-DRAFT)) -
 facilitates communication between different software components, ensuring they work together without conflicts.
 
@@ -64,35 +70,6 @@ For example:
 - Open Container Initiative (OCI) Image Specification – standard metadata format for container images, including layers, dependencies, and authorship.
 - Dockerfile - defines base images, environment variables, and configurations for containerised applications.
 - Kubernetes metadata - provides metadata for managing deployments, services, and pods in Kubernetes clusters.
-
-## Using CodeMeta to describe software
-
-{% tool "codemeta" %} is a community-developed metadata standard designed to describe and exchange metadata about research software projects in a structured way.
-It provides a machine-readable JSON-LD format (in the form of `codemeta.json` file attached to your software project) for storing metadata about software, including authorship, licensing, dependencies, versioning, and more.
-It consists of a set of properties that extend [Schema.org](https://schema.org) (a popular metadata vocabulary designed to describe Digital Objects on the Web) with software-specific metadata (e.g. maintainer, build instructions, software documentation, etc.).
-
-It was created to standardise metadata across different repositories and programming ecosystems, making it easier to share, discover, and cite software.
-See the [CodeMeta terms](https://codemeta.github.io/terms/) to understand which terms are used to describe software.
-
-### Who uses CodeMeta?
-
-- GitHub & GitLab code repositories support it to help document software for better discoverability.
-- Researchers use it to cite research software in academic papers.
-- Software repositories & archives like {% tool "zenodo" %}, {% tool "figshare" %}, {% tool "inveniordm" %} and {% tool "software-heritage" %}, as well as many institutional repositories use it as a standardised metadata format across platforms.
-- FAIR data initiatives support the use of CodeMeta format to [help with findability](https://zenodo.org/records/13996966/files/DASH_FAIR_CodeMeta_Oct_2024.pdf).
-
-### How can you use CodeMeta?
-
-You can use the [CodeMeta terms](https://codemeta.github.io/terms/) to create a `codemeta.json` file for your software projects and share it in the root of the source code repository (e.g. on GitHub & GitLab) along with your code.
-
-You can create the `codemeta.json` file:
-* by using {% tool "codemeta-generator" %}, an online form-based service to help you describe valid CodeMeta records.
-* by using {% tool "somef" %} command line tool and using the `-c` flag to export the CodeMeta file generated from your README file and available documentation. 
-Alternatively, {% tool "somef-vider" %} will allow you to download auto-generated CodeMeta files (remember to double check the results).
-* manually, e.g. by using the [CodeMeta template](https://github.com/codemeta/codemeta/blob/master/codemeta.json) as a reference. JSON-LD files can be validated with services like {% tool "jasonldvalidator" %}.
-
-Using CodeMeta file to describe your software will propagate between different archival infrastructures, platforms and services which understand CodeMeta descriptions and can ingest existing `codemeta.json` files automatically ({% tool "zenodo" %}, {% tool "figshare" %}, {% tool "inveniordm" %} and {% tool "software-heritage" %}).
-This means you will not have to duplicate the work when using such services - e.g. when [obtaining a DOI for your software](./software_identifiers), if you have `codemeta.json` file already you will not have to fill in the corresponding software metadata again.
 
 {% assign child_pages = page.child_pages | join: ', ' %}
 {% if child_pages != null and child_pages != '' %}

--- a/pages/tasks/software_metadata.md
+++ b/pages/tasks/software_metadata.md
@@ -34,7 +34,7 @@ The type of metadata you need from software depends on your specific use case.
 - If you're aiming to replicate an analysis, versioning and dependencies matter more than authorship or titles.
 - If you're searching for new software suited to a particular task, keywords and descriptions are most relevant.
 
-Often, developers of researcg software, repositories that host it, and users have multiple objectives—sometimes balancing several of these needs at once.
+Often, developers of research software, repositories that host it, and users have multiple objectives—sometimes balancing several of these needs at once.
 
 ### Solutions
 


### PR DESCRIPTION
This PR removes redundancies between the software metadata page and the bibliographic citation metadata with codemeta.

Changes proposed in this pull request:

* Renamed the `bibliographic metadata` to `software metadata`, since it addresses a full codemeta record. I hope it does not cause link breaks, I tried my best not to break them
* Updated tool lists in both pages to make it coherent. Homogenized descriptions as well and combined them
* Moved the codemeta descriptions to a single page. Before we had them in both.
* Fixed and validated the codemeta snippet with the playground app (it had 2 minor errors and the wrong ns)
* Added a link to CFF too, since we mention bibliographic metadata (i.e., citation). I added the link to the page we have

